### PR TITLE
Added Client token and Introspect token test for swagger

### DIFF
--- a/oxd-common/src/main/java/org/xdi/oxd/common/response/GetClientTokenResponse.java
+++ b/oxd-common/src/main/java/org/xdi/oxd/common/response/GetClientTokenResponse.java
@@ -2,6 +2,8 @@ package org.xdi.oxd.common.response;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import java.util.List;
+
 /**
  * @author Yuriy Zabrovarnyy
  * @version 0.9, 31/03/2017
@@ -16,7 +18,7 @@ public class GetClientTokenResponse implements IOpResponse {
     @JsonProperty(value = "refresh_token")
     private String refreshToken;
     @JsonProperty(value = "scope")
-    private String scope;
+    private List<String> scope;
 
     public String getAccessToken() {
         return accessToken;
@@ -42,11 +44,11 @@ public class GetClientTokenResponse implements IOpResponse {
         this.refreshToken = refreshToken;
     }
 
-    public String getScope() {
+    public List<String> getScope() {
         return scope;
     }
 
-    public void setScope(String scope) {
+    public void setScope(List<String> scope) {
         this.scope = scope;
     }
 

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetClientTokenResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetClientTokenResponseData.java
@@ -22,6 +22,8 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * GetClientTokenResponseData
@@ -29,7 +31,7 @@ import java.io.IOException;
 
 public class GetClientTokenResponseData {
   @SerializedName("scope")
-  private String scope = null;
+  private List<String> scope = new ArrayList<>();
 
   @SerializedName("access_token")
   private String accessToken = null;
@@ -40,8 +42,13 @@ public class GetClientTokenResponseData {
   @SerializedName("refresh_token")
   private String refreshToken = null;
 
-  public GetClientTokenResponseData scope(String scope) {
+  public GetClientTokenResponseData scope(List<String> scope) {
     this.scope = scope;
+    return this;
+  }
+
+  public GetClientTokenResponseData addScopeItem(String scopeItem) {
+    this.scope.add(scopeItem);
     return this;
   }
 
@@ -49,12 +56,12 @@ public class GetClientTokenResponseData {
    * Get scope
    * @return scope
   **/
-  @ApiModelProperty(example = "", required = true, value = "")
-  public String getScope() {
+  @ApiModelProperty(example = "[\"openid\",\"blah\"]", required = true, value = "")
+  public List<String> getScope() {
     return scope;
   }
 
-  public void setScope(String scope) {
+  public void setScope(List<String> scope) {
     this.scope = scope;
   }
 

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteResponseData.java
@@ -31,6 +31,15 @@ public class UpdateSiteResponseData {
   @SerializedName("oxd_id")
   private String oxdId = null;
 
+  @SerializedName("error")
+  private String error = null;
+
+  @SerializedName("errorDescription")
+  private String errorDescription = null;
+
+  @SerializedName("details")
+  private Object details = null;
+
   public UpdateSiteResponseData oxdId(String oxdId) {
     this.oxdId = oxdId;
     return this;
@@ -40,13 +49,67 @@ public class UpdateSiteResponseData {
    * Get oxdId
    * @return oxdId
   **/
-  @ApiModelProperty(example = "bcad760f-91ba-46e1-a020-05e4281d91b6", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   public String getOxdId() {
     return oxdId;
   }
 
   public void setOxdId(String oxdId) {
     this.oxdId = oxdId;
+  }
+
+  public UpdateSiteResponseData error(String error) {
+    this.error = error;
+    return this;
+  }
+
+   /**
+   * Get error
+   * @return error
+  **/
+  @ApiModelProperty(value = "")
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+
+  public UpdateSiteResponseData errorDescription(String errorDescription) {
+    this.errorDescription = errorDescription;
+    return this;
+  }
+
+   /**
+   * Get errorDescription
+   * @return errorDescription
+  **/
+  @ApiModelProperty(value = "")
+  public String getErrorDescription() {
+    return errorDescription;
+  }
+
+  public void setErrorDescription(String errorDescription) {
+    this.errorDescription = errorDescription;
+  }
+
+  public UpdateSiteResponseData details(Object details) {
+    this.details = details;
+    return this;
+  }
+
+   /**
+   * Get details
+   * @return details
+  **/
+  @ApiModelProperty(value = "")
+  public Object getDetails() {
+    return details;
+  }
+
+  public void setDetails(Object details) {
+    this.details = details;
   }
 
 
@@ -59,12 +122,15 @@ public class UpdateSiteResponseData {
       return false;
     }
     UpdateSiteResponseData updateSiteResponseData = (UpdateSiteResponseData) o;
-    return Objects.equals(this.oxdId, updateSiteResponseData.oxdId);
+    return Objects.equals(this.oxdId, updateSiteResponseData.oxdId) &&
+        Objects.equals(this.error, updateSiteResponseData.error) &&
+        Objects.equals(this.errorDescription, updateSiteResponseData.errorDescription) &&
+        Objects.equals(this.details, updateSiteResponseData.details);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(oxdId);
+    return Objects.hash(oxdId, error, errorDescription, details);
   }
 
 
@@ -74,6 +140,9 @@ public class UpdateSiteResponseData {
     sb.append("class UpdateSiteResponseData {\n");
     
     sb.append("    oxdId: ").append(toIndentedString(oxdId)).append("\n");
+    sb.append("    error: ").append(toIndentedString(error)).append("\n");
+    sb.append("    errorDescription: ").append(toIndentedString(errorDescription)).append("\n");
+    sb.append("    details: ").append(toIndentedString(details)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/BaseTestCase.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/BaseTestCase.java
@@ -1,0 +1,10 @@
+package io.swagger.client.api;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(value = TestMethodListener.class)
+public class BaseTestCase  {
+
+}
+
+

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/EnabledProtectionAccessToken.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/EnabledProtectionAccessToken.java
@@ -1,0 +1,16 @@
+package io.swagger.client.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to skip the test if protection access token configuration is set to false
+ *
+ * @author Shoeb
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface EnabledProtectionAccessToken {
+}

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/GetClientTokenTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/GetClientTokenTest.java
@@ -1,0 +1,36 @@
+package io.swagger.client.api;
+
+import static org.testng.Assert.assertNotNull;
+
+import com.google.common.collect.Lists;
+import io.swagger.client.ApiException;
+import io.swagger.client.model.GetClientTokenParams;
+import io.swagger.client.model.GetClientTokenResponseData;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+
+
+/**
+ * @author Yuriy Zabrovarnyy
+ * @author Shoeb
+ * @version 9/17/2018
+ */
+
+public class GetClientTokenTest {
+
+    @Parameters({ "opHost"})
+    @Test
+    public void getClientToken(String opHost) throws ApiException {
+        final GetClientTokenParams params = new GetClientTokenParams();
+        params.setOpHost(opHost);
+        params.setScope(Lists.newArrayList("openid","oxd"));
+        params.setClientId(Tester.getSetupData().getClientId());
+        params.setClientSecret(Tester.getSetupData().getClientSecret());
+
+        GetClientTokenResponseData resp = Tester.api().getClientToken(params).getData();
+        assertNotNull(resp);
+        Tester.notEmpty(resp.getAccessToken());
+
+    }
+}

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
@@ -36,18 +36,15 @@ public class IntrospectAccessTokenTest extends BaseTestCase {
         //
         final String authorization = "Bearer " + accessToken;
         final IntrospectAccessTokenResponse iaTokenResponse = client.introspectAccessToken(authorization, introspectParams);
-        IntrospectAccessTokenResponseData iatResponseData = iaTokenResponse.getData();
-        assertNotNull(iatResponseData);
-        assertTrue(iatResponseData.isActive());
-        final Long issuedAt = iatResponseData.getIat();
-        assertNotNull(issuedAt);
-        Long expiresAt = iatResponseData.getExp();
-        assertNotNull(expiresAt);
-        assertTrue(expiresAt >= issuedAt);
-        final Long nbf = iatResponseData.getNbf();
+        assertNotNull(iaTokenResponse.getData());
+        assertTrue(iaTokenResponse.getData().isActive());
+        assertNotNull(iaTokenResponse.getData().getIat());
+        assertNotNull(iaTokenResponse.getData().getExp());
+        assertTrue(iaTokenResponse.getData().getExp() >= iaTokenResponse.getData().getIat());
+        final Long nbf = iaTokenResponse.getData().getNbf();
         if (nbf != null) {
-            assertTrue(nbf > issuedAt);
-            assertTrue(nbf < expiresAt);
+            assertTrue(nbf > iaTokenResponse.getData().getIat());
+            assertTrue(nbf < iaTokenResponse.getData().getExp());
         }
     }
 
@@ -79,12 +76,12 @@ public class IntrospectAccessTokenTest extends BaseTestCase {
         IntrospectAccessTokenResponseData responseData = apiIatResponse.getData().getData();
         assertNotNull(responseData);
         // verify client is NOT active
-        assertEquals(responseData.isActive(), Boolean.FALSE);
+        assertFalse(responseData.isActive());
     }
 
     @Parameters({"opHost", "redirectUrl"})
     @Test
-    @EnabledProtectionAccessToken
+    @ProtectionAccessTokenRequired
     public void testWithInvalidAuthorization(String opHost, String redirectUrl) throws Exception {
 
         DevelopersApi client = Tester.api();
@@ -108,9 +105,8 @@ public class IntrospectAccessTokenTest extends BaseTestCase {
 
     }
 
-    private static GetClientTokenResponseData getGetClientTokenResponseData(
-            String opHost, DevelopersApi client, RegisterSiteResponseData setupResponse)
-            throws ApiException {
+    private static GetClientTokenResponseData getGetClientTokenResponseData(String opHost, DevelopersApi client,
+                                                                            RegisterSiteResponseData setupResponse) throws ApiException {
         final GetClientTokenParams params = new GetClientTokenParams();
         params.setOpHost(opHost);
         params.setScope(Lists.newArrayList("openid","oxd"));

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
@@ -1,0 +1,126 @@
+package io.swagger.client.api;
+
+import com.google.common.collect.Lists;
+import io.swagger.client.ApiException;
+import io.swagger.client.ApiResponse;
+import io.swagger.client.model.GetClientTokenParams;
+import io.swagger.client.model.GetClientTokenResponse;
+import io.swagger.client.model.GetClientTokenResponseData;
+import io.swagger.client.model.IntrospectAccessTokenParams;
+import io.swagger.client.model.IntrospectAccessTokenResponse;
+import io.swagger.client.model.IntrospectAccessTokenResponseData;
+import io.swagger.client.model.RegisterSiteResponseData;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import static junit.framework.Assert.*;
+
+/**
+ * @author yuriyz
+ * @author Shoeb
+ */
+public class IntrospectAccessTokenTest extends BaseTestCase {
+
+    @Parameters({"opHost", "redirectUrl"})
+    @Test
+    public void introspectAccessToken(String opHost, String redirectUrl) throws Exception {
+        DevelopersApi client = Tester.api();
+        RegisterSiteResponseData setupResponse = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        GetClientTokenResponseData tokenResponse = getGetClientTokenResponseData(opHost, client, setupResponse);
+        assertNotNull(tokenResponse);
+        final String accessToken = tokenResponse.getAccessToken();
+        Tester.notEmpty(accessToken);
+        IntrospectAccessTokenParams introspectParams = new IntrospectAccessTokenParams();
+        introspectParams.setOxdId(setupResponse.getOxdId());
+        introspectParams.setAccessToken(accessToken);
+        //
+        final String authorization = "Bearer " + accessToken;
+        final IntrospectAccessTokenResponse iaTokenResponse = client.introspectAccessToken(authorization, introspectParams);
+        IntrospectAccessTokenResponseData iatResponseData = iaTokenResponse.getData();
+        assertNotNull(iatResponseData);
+        assertTrue(iatResponseData.isActive());
+        final Long issuedAt = iatResponseData.getIat();
+        assertNotNull(issuedAt);
+        Long expiresAt = iatResponseData.getExp();
+        assertNotNull(expiresAt);
+        assertTrue(expiresAt >= issuedAt);
+        final Long nbf = iatResponseData.getNbf();
+        if (nbf != null) {
+            assertTrue(nbf > issuedAt);
+            assertTrue(nbf < expiresAt);
+        }
+    }
+
+    /*
+    According to open id spec, introspect access token API, for authorized request with an invalid
+    token, should not throw an error but should return the client as inactive.
+     */
+    @Parameters({"opHost", "redirectUrl"})
+    @Test
+    public void testWithInvalidToken(String opHost, String redirectUrl) throws Exception {
+        DevelopersApi client = Tester.api();
+        RegisterSiteResponseData setupData = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+
+        GetClientTokenResponseData tokenResponse = getGetClientTokenResponseData(opHost, client, setupData);
+        assertNotNull(tokenResponse);
+        final String accessToken = tokenResponse.getAccessToken();
+        final String validHeader = "Bearer " + accessToken;
+        final String invalidToken = accessToken.concat("BlahBlah");
+
+        IntrospectAccessTokenParams iatParams = new IntrospectAccessTokenParams();
+        iatParams.setAccessToken(invalidToken);
+        iatParams.setOxdId(setupData.getOxdId());
+
+        ApiResponse<IntrospectAccessTokenResponse>
+                apiIatResponse = client.introspectAccessTokenWithHttpInfo(validHeader, iatParams);
+        assertEquals(apiIatResponse.getStatusCode(), 200);
+        assertNotNull(apiIatResponse.getData());
+
+        IntrospectAccessTokenResponseData responseData = apiIatResponse.getData().getData();
+        assertNotNull(responseData);
+        // verify client is NOT active
+        assertEquals(responseData.isActive(), Boolean.FALSE);
+    }
+
+    @Parameters({"opHost", "redirectUrl"})
+    @Test
+    @EnabledProtectionAccessToken
+    public void testWithInvalidAuthorization(String opHost, String redirectUrl) throws Exception {
+
+        DevelopersApi client = Tester.api();
+        RegisterSiteResponseData setupResponse = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+
+        GetClientTokenResponseData tokenResponseData = this.getGetClientTokenResponseData(opHost, client, setupResponse);
+        IntrospectAccessTokenParams introspectParams = new IntrospectAccessTokenParams();
+        introspectParams.setOxdId(setupResponse.getOxdId());
+        introspectParams.setAccessToken(tokenResponseData.getAccessToken());
+
+        final String invalidAuthString = "Bearer " + "NotAuthorized";
+        final ApiResponse<IntrospectAccessTokenResponse> introApiResponse =
+                client.introspectAccessTokenWithHttpInfo(invalidAuthString, introspectParams);
+
+        //Fixme: Status code should be 401
+        assertTrue(introApiResponse.getStatusCode() == 200);
+
+        IntrospectAccessTokenResponseData responseData = introApiResponse.getData().getData();
+        assertNotNull(responseData);
+        assertNull(responseData.getClientId());
+
+    }
+
+    private static GetClientTokenResponseData getGetClientTokenResponseData(
+            String opHost, DevelopersApi client, RegisterSiteResponseData setupResponse)
+            throws ApiException {
+        final GetClientTokenParams params = new GetClientTokenParams();
+        params.setOpHost(opHost);
+        params.setScope(Lists.newArrayList("openid","oxd"));
+        params.setClientId(setupResponse.getClientId());
+        params.setClientSecret(setupResponse.getClientSecret());
+
+        final GetClientTokenResponse clientTokenResponse = client.getClientToken(params);
+        assertNotNull(clientTokenResponse);
+        return clientTokenResponse.getData();
+    }
+
+
+}

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/ProtectionAccessTokenRequired.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/ProtectionAccessTokenRequired.java
@@ -12,5 +12,5 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface EnabledProtectionAccessToken {
+public @interface ProtectionAccessTokenRequired {
 }

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RegisterSiteTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RegisterSiteTest.java
@@ -67,7 +67,7 @@ public class RegisterSiteTest {
         final UpdateSiteParams params = new UpdateSiteParams();
         params.setOxdId(oxdId);
         params.setClientSecretExpiresAt(calendar.getTime().getTime());
-        params.setScope(Lists.newArrayList("profile"));
+        params.setScope(Lists.newArrayList("profile", "oxd"));
         final DevelopersApi apiClient = api();
         UpdateSiteResponse resp = apiClient.updateSite(getAuthorization(), params);
         assertNotNull(resp);
@@ -90,7 +90,7 @@ public class RegisterSiteTest {
         params.setAuthorizationRedirectUri(redirectUrl);
         params.setPostLogoutRedirectUri(postLogoutRedirectUrl);
         params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUri));
-        params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
+        params.setScope(Lists.newArrayList("openid", "uma_protection", "profile","oxd"));
         params.setTrustedClient(true);
         params.setGrantTypes(Lists.newArrayList(
                 GrantType.AUTHORIZATION_CODE.getValue(),

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RemoveSiteTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RemoveSiteTest.java
@@ -24,7 +24,7 @@ public class RemoveSiteTest {
         RemoveSiteParams params = new RemoveSiteParams();
         params.setOxdId(response.getOxdId());
 
-        RemoveSiteResponse removeSiteResp = api.removeSite(Tester.getAuthorization(), params);
+        RemoveSiteResponse removeSiteResp = api.removeSite(Tester.getAuthorization(response), params);
         assertNotNull(removeSiteResp);
         assertNotNull(removeSiteResp.getData());
         assertTrue(StringUtils.isNotEmpty(removeSiteResp.getData().getOxdId()));

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/SetUpTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/SetUpTest.java
@@ -38,4 +38,9 @@ public class SetUpTest {
             throw new AssertionError("Failed to start suite.");
         }
     }
+
+    public static void setTokenProtectionEnabled(Boolean isTokenProtectionEnabled) {
+        Tester.setTokenProtectionEnabled(isTokenProtectionEnabled);
+    }
+
 }

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/TestMethodListener.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/TestMethodListener.java
@@ -1,0 +1,36 @@
+package io.swagger.client.api;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.SkipException;
+
+import java.lang.reflect.Method;
+
+/**
+ *  Listener class to be attached to test classes to augment test ng behavior
+ *
+ * @author Shoeb
+ */
+public class TestMethodListener implements IInvokedMethodListener {
+
+    @Override
+    public void beforeInvocation(IInvokedMethod iInvokedMethod, ITestResult iTestResult) {
+        Method method = iTestResult.getMethod().getConstructorOrMethod().getMethod();
+        if (method == null) {
+            return;
+        }
+        if (method.isAnnotationPresent(EnabledProtectionAccessToken.class)) {
+            if (!Tester.isTokenProtectionEnabled()) {
+                iTestResult.setStatus(ITestResult.SKIP);
+                throw new SkipException("Skipping the test as protection access token is not enabled. Ignore the exception.");
+            }
+        }
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod iInvokedMethod, ITestResult iTestResult) {
+
+    }
+
+}

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/TestMethodListener.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/TestMethodListener.java
@@ -20,7 +20,7 @@ public class TestMethodListener implements IInvokedMethodListener {
         if (method == null) {
             return;
         }
-        if (method.isAnnotationPresent(EnabledProtectionAccessToken.class)) {
+        if (method.isAnnotationPresent(ProtectionAccessTokenRequired.class)) {
             if (!Tester.isTokenProtectionEnabled()) {
                 iTestResult.setStatus(ITestResult.SKIP);
                 throw new SkipException("Skipping the test as protection access token is not enabled. Ignore the exception.");

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/Tester.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/Tester.java
@@ -25,7 +25,7 @@ public class Tester {
     private static String HOST;
     private static String OP_HOST;
     private static RegisterSiteResponseData setupData;
-    private static Boolean isTokenProtectionEnabled = Boolean.FALSE;
+    private static boolean isTokenProtectionEnabled = false;
 
     private Tester() {
     }

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/Tester.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/Tester.java
@@ -4,12 +4,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import io.swagger.client.ApiClient;
+import io.swagger.client.ApiException;
 import io.swagger.client.model.GetClientTokenParams;
 import io.swagger.client.model.GetClientTokenResponseData;
 import io.swagger.client.model.RegisterSiteResponseData;
-import org.testng.AssertJUnit;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -24,6 +25,7 @@ public class Tester {
     private static String HOST;
     private static String OP_HOST;
     private static RegisterSiteResponseData setupData;
+    private static Boolean isTokenProtectionEnabled = Boolean.FALSE;
 
     private Tester() {
     }
@@ -34,6 +36,7 @@ public class Tester {
 
         apiClient.setVerifyingSsl(false);
         apiClient.setDebugging(true);
+        apiClient.getHttpClient().setConnectTimeout(10, TimeUnit.SECONDS);
 
         return new DevelopersApi(apiClient);
     }
@@ -49,18 +52,33 @@ public class Tester {
     public static String getAuthorization() throws Exception {
         Preconditions.checkNotNull(setupData);
         if (Strings.isNullOrEmpty(AUTHORIZATION)) {
-            final GetClientTokenParams params = new GetClientTokenParams();
-            params.setOpHost(OP_HOST);
-            params.setScope(Lists.newArrayList("openid"));
-            params.setClientId(setupData.getClientId());
-            params.setClientSecret(setupData.getClientSecret());
-
-            GetClientTokenResponseData resp = api().getClientToken(params).getData();
-            assertNotNull(resp);
-            AssertJUnit.assertTrue(!Strings.isNullOrEmpty(resp.getAccessToken()));
-            AUTHORIZATION = "Bearer " + resp.getAccessToken();
+            AUTHORIZATION = "Bearer " + getAuthorization(setupData);
         }
         return AUTHORIZATION;
+    }
+
+    /**
+     * Tests requiring register site operation to be performed before their execution better call this method instead of the overloaded no-arg method.
+     * This ensures, a new access token is generated for the new client site.
+     *
+     * Note:- This IS a requirement in case value of protect_commands_with_access_token is set to true in server configuration.
+     *
+     * @param siteResponseData
+     * @return access token for the provided site's client id
+     * @throws ApiException
+     */
+    public static String getAuthorization(RegisterSiteResponseData siteResponseData) throws ApiException {
+        final GetClientTokenParams params = new GetClientTokenParams();
+        params.setOpHost(OP_HOST);
+        params.setScope(Lists.newArrayList("openid", "oxd"));
+        params.setClientId(siteResponseData.getClientId());
+        params.setClientSecret(siteResponseData.getClientSecret());
+
+        GetClientTokenResponseData resp = api().getClientToken(params).getData();
+        assertNotNull(resp);
+        assertTrue(!Strings.isNullOrEmpty(resp.getAccessToken()));
+
+        return "Bearer " + resp.getAccessToken();
     }
 
 
@@ -74,5 +92,17 @@ public class Tester {
 
     public static void setSetupData(RegisterSiteResponseData setupData) {
         Tester.setupData = setupData;
+    }
+
+    public static void setTokenProtectionEnabled(Boolean isTokenProtectionEnabled) {
+        Tester.isTokenProtectionEnabled = isTokenProtectionEnabled;
+    }
+
+    public static RegisterSiteResponseData getSetupData() {
+        return setupData;
+    }
+
+    public static Boolean isTokenProtectionEnabled() {
+        return isTokenProtectionEnabled;
     }
 }

--- a/oxd-server/src/main/java/org/xdi/oxd/server/Utils.java
+++ b/oxd-server/src/main/java/org/xdi/oxd/server/Utils.java
@@ -12,8 +12,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Utility class with static methods.
@@ -90,5 +92,9 @@ public class Utils {
 
     public static boolean isTrue(Boolean bool) {
         return bool != null && bool;
+    }
+
+    public static List<String> stringToList(String source) {
+        return Arrays.asList(source.split("\\s+"));
     }
 }

--- a/oxd-server/src/main/java/org/xdi/oxd/server/op/GetAccessTokenByRefreshTokenOperation.java
+++ b/oxd-server/src/main/java/org/xdi/oxd/server/op/GetAccessTokenByRefreshTokenOperation.java
@@ -48,7 +48,7 @@ public class GetAccessTokenByRefreshTokenOperation extends BaseOperation<GetAcce
                     response.setAccessToken(tokenResponse.getAccessToken());
                     response.setExpiresIn(tokenResponse.getExpiresIn());
                     response.setRefreshToken(tokenResponse.getRefreshToken());
-                    response.setScope(tokenResponse.getScope());
+                    response.setScope(Utils.stringToList(tokenResponse.getScope()));
 
                     return okResponse(response);
                 } else {

--- a/oxd-server/src/main/java/org/xdi/oxd/server/op/GetClientTokenOperation.java
+++ b/oxd-server/src/main/java/org/xdi/oxd/server/op/GetClientTokenOperation.java
@@ -78,7 +78,7 @@ public class GetClientTokenOperation extends BaseOperation<GetClientTokenParams>
                     response.setAccessToken(tokenResponse.getAccessToken());
                     response.setExpiresIn(tokenResponse.getExpiresIn());
                     response.setRefreshToken(tokenResponse.getRefreshToken());
-                    response.setScope(tokenResponse.getScope());
+                    response.setScope(Utils.stringToList(tokenResponse.getScope()));
 
                     return okResponse(response);
                 } else {

--- a/oxd-server/src/main/resources/swagger.yaml
+++ b/oxd-server/src/main/resources/swagger.yaml
@@ -104,8 +104,10 @@ paths:
                   - refresh_token
                 properties:
                   scope:
-                    type: string
-                    example: ["openid"]
+                    type: array
+                    items:
+                      type: string
+                    example: ["openid","oxd"]
                   access_token:
                     type: string
                     example: b75434ff-f465-4b70-92e4-b7ba6b6c58f2

--- a/oxd-server/src/test/java/org/xdi/oxd/server/IntrospectAccessTokenTest.java
+++ b/oxd-server/src/test/java/org/xdi/oxd/server/IntrospectAccessTokenTest.java
@@ -12,6 +12,7 @@ import org.xdi.oxd.common.response.GetClientTokenResponse;
 import org.xdi.oxd.common.response.RegisterSiteResponse;
 
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
 import static org.xdi.oxd.server.TestUtils.notEmpty;
 
 /**
@@ -44,7 +45,14 @@ public class IntrospectAccessTokenTest {
 
         IntrospectionResponse introspectionResponse = client.introspectAccessToken("Bearer " + tokenResponse.getAccessToken(), introspectParams).dataAsResponse(IntrospectionResponse.class);
         assertNotNull(introspectionResponse);
-        Assert.assertTrue(introspectionResponse.isActive());
+        assertTrue(introspectionResponse.isActive());
+
+        final Integer issuedAt = introspectionResponse.getIssuedAt();
+        assertNotNull(issuedAt);
+        Integer expiresAt = introspectionResponse.getExpiresAt();
+        assertNotNull(expiresAt);
+        assertTrue(expiresAt >= issuedAt);
+        //todo : add check for nbf when ready
 
     }
 }

--- a/oxd-server/src/test/java/org/xdi/oxd/server/SetUpTest.java
+++ b/oxd-server/src/test/java/org/xdi/oxd/server/SetUpTest.java
@@ -66,6 +66,7 @@ public class SetUpTest {
                 host = host + ":" + SetUpTest.SUPPORT.getLocalPort();
             }
             io.swagger.client.api.SetUpTest.beforeSuite(host, opHost, redirectUrl); // manual swagger tests setup
+            io.swagger.client.api.SetUpTest.setTokenProtectionEnabled(SUPPORT.getConfiguration().getProtectCommandsWithAccessToken());
         } catch (Throwable e) {
             LOG.error("Failed to setup swagger suite.");
         }

--- a/oxd-server/src/test/resources/testng.xml
+++ b/oxd-server/src/test/resources/testng.xml
@@ -139,4 +139,17 @@
             <class name="io.swagger.client.api.RemoveSiteTest"/>
         </classes>
     </test>
+
+    <test name="Get client token swagger" enabled="true">
+        <classes>
+            <class name="io.swagger.client.api.GetClientTokenTest"/>
+        </classes>
+    </test>
+
+    <test name="Introspect access token swagger" enabled="true">
+        <classes>
+            <class name="io.swagger.client.api.IntrospectAccessTokenTest"/>
+        </classes>
+    </test>
+
 </suite>

--- a/oxd-server/src/test/resources/testng.xml
+++ b/oxd-server/src/test/resources/testng.xml
@@ -128,6 +128,12 @@
 
     <!-- SWAGGER TESTS -->
 
+    <test name="Register site swagger" enabled="true">
+        <classes>
+            <class name="io.swagger.client.api.RegisterSiteTest"/>
+        </classes>
+    </test>
+
     <test name="Remove site swagger" enabled="true">
         <classes>
             <class name="io.swagger.client.api.RemoveSiteTest"/>


### PR DESCRIPTION
Tests for client token and introspect token based on swagger client have been developed. As some tests work only when protection command access token is enabled, so some functionality has been added to skip the tests when the configuration doesn't match.