### PR TITLE
Issue#236 - Exception enhancement  for mismatched clients

### DIFF
--- a/oxd-common/src/main/java/org/xdi/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/xdi/oxd/common/ErrorResponseCode.java
@@ -33,6 +33,7 @@ public enum ErrorResponseCode {
     INVALID_ID_TOKEN_BAD_NONCE("invalid_id_token_bad_nonce", "Invalid id_token. Nonce value from token does not match nonce from request."),
     INVALID_ID_TOKEN_BAD_AUDIENCE("invalid_id_token_bad_audience", "Invalid id_token. Audience value from token does not match audience from request."),
     INVALID_ID_TOKEN_EXPIRED("invalid_id_token_expired", "Invalid id_token. id_token expired."),
+    INVALID_ID_TOKEN_MISMATCHED_CLIENT_ID("invalid_id_token_mismatch_client_id", "Invalid id_token. Client id linked with id_token doesn't match with client id for site."),
     INVALID_ID_TOKEN_BAD_ISSUER("invalid_id_token_bad_issuer", "Invalid id_token. Bad issuer."),
     INVALID_ID_TOKEN_BAD_SIGNATURE("invalid_id_token_bad_signature", "Invalid id_token. Bad signature."),
     INVALID_ID_TOKEN_UNKNOWN("invalid_id_token_unknown", "Invalid id_token, validation fail due to exception, please check oxd-server.log for details."),

--- a/oxd-common/src/main/java/org/xdi/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/xdi/oxd/common/ErrorResponseCode.java
@@ -33,7 +33,7 @@ public enum ErrorResponseCode {
     INVALID_ID_TOKEN_BAD_NONCE("invalid_id_token_bad_nonce", "Invalid id_token. Nonce value from token does not match nonce from request."),
     INVALID_ID_TOKEN_BAD_AUDIENCE("invalid_id_token_bad_audience", "Invalid id_token. Audience value from token does not match audience from request."),
     INVALID_ID_TOKEN_EXPIRED("invalid_id_token_expired", "Invalid id_token. id_token expired."),
-    INVALID_ID_TOKEN_MISMATCHED_CLIENT_ID("invalid_id_token_mismatch_client_id", "Invalid id_token. Client id linked with id_token doesn't match with client id for site."),
+    INVALID_ACCESS_TOKEN_MISMATCHED_CLIENT_ID("invalid_access_token_mismatch_client_id", "Invalid access_token. Client id linked with id_token doesn't match with client id for site."),
     INVALID_ID_TOKEN_BAD_ISSUER("invalid_id_token_bad_issuer", "Invalid id_token. Bad issuer."),
     INVALID_ID_TOKEN_BAD_SIGNATURE("invalid_id_token_bad_signature", "Invalid id_token. Bad signature."),
     INVALID_ID_TOKEN_UNKNOWN("invalid_id_token_unknown", "Invalid id_token, validation fail due to exception, please check oxd-server.log for details."),

--- a/oxd-gen-client/src/main/java/io/swagger/client/ApiException.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/ApiException.java
@@ -16,7 +16,7 @@ package io.swagger.client;
 import java.util.Map;
 import java.util.List;
 
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/Configuration.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package io.swagger.client;
 
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/oxd-gen-client/src/main/java/io/swagger/client/Pair.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/Pair.java
@@ -13,7 +13,7 @@
 
 package io.swagger.client;
 
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/oxd-gen-client/src/main/java/io/swagger/client/StringUtil.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/StringUtil.java
@@ -13,7 +13,7 @@
 
 package io.swagger.client;
 
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/oxd-gen-client/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
@@ -18,7 +18,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/oxd-gen-client/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/auth/OAuth.java
@@ -18,7 +18,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class OAuth implements Authentication {
   private String accessToken;
 

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAccessTokenByRefreshTokenParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAccessTokenByRefreshTokenParams.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetAccessTokenByRefreshTokenParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetAccessTokenByRefreshTokenParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAccessTokenByRefreshTokenResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAccessTokenByRefreshTokenResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * GetAccessTokenByRefreshTokenResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetAccessTokenByRefreshTokenResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAccessTokenByRefreshTokenResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAccessTokenByRefreshTokenResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetAccessTokenByRefreshTokenResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetAccessTokenByRefreshTokenResponseData {
   @SerializedName("scope")
   private String scope = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlParams.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * GetAuthorizationUrlParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetAuthorizationUrlParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * GetAuthorizationUrlResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetAuthorizationUrlResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetAuthorizationUrlResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetAuthorizationUrlResponseData {
   @SerializedName("authorization_url")
   private String authorizationUrl = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetClientTokenParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetClientTokenParams.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetClientTokenParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetClientTokenParams {
   @SerializedName("op_host")
   private String opHost = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetClientTokenResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetClientTokenResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * GetClientTokenResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetClientTokenResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetClientTokenResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetClientTokenResponseData.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetClientTokenResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetClientTokenResponseData {
   @SerializedName("scope")
   private List<String> scope = new ArrayList<>();
@@ -56,7 +56,7 @@ public class GetClientTokenResponseData {
    * Get scope
    * @return scope
   **/
-  @ApiModelProperty(example = "[\"openid\",\"blah\"]", required = true, value = "")
+  @ApiModelProperty(example = "[\"openid\",\"oxd\"]", required = true, value = "")
   public List<String> getScope() {
     return scope;
   }

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetLogoutUriParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetLogoutUriParams.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetLogoutUriParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetLogoutUriParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetLogoutUriResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetLogoutUriResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * GetLogoutUriResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetLogoutUriResponse {
   @SerializedName("claims")
   private GetLogoutUriResponseClaims claims = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetLogoutUriResponseClaims.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetLogoutUriResponseClaims.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetLogoutUriResponseClaims
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetLogoutUriResponseClaims {
   @SerializedName("url")
   private String url = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetTokensByCodeParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetTokensByCodeParams.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetTokensByCodeParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetTokensByCodeParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetTokensByCodeResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetTokensByCodeResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * GetTokensByCodeResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetTokensByCodeResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetTokensByCodeResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetTokensByCodeResponseData.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * GetTokensByCodeResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetTokensByCodeResponseData {
   @SerializedName("access_token")
   private String accessToken = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetTokensByCodeResponseDataIdTokenClaims.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetTokensByCodeResponseDataIdTokenClaims.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetTokensByCodeResponseDataIdTokenClaims
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetTokensByCodeResponseDataIdTokenClaims {
   @SerializedName("at_hash")
   private List<String> atHash = new ArrayList<>();

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetUserInfoParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetUserInfoParams.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetUserInfoParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetUserInfoParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetUserInfoResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetUserInfoResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * GetUserInfoResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetUserInfoResponse {
   @SerializedName("claims")
   private GetUserInfoResponseClaims claims = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetUserInfoResponseClaims.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetUserInfoResponseClaims.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * GetUserInfoResponseClaims
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetUserInfoResponseClaims {
   @SerializedName("sub")
   private List<String> sub = new ArrayList<>();

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetauthorizationurlCustomParameters.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetauthorizationurlCustomParameters.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * GetauthorizationurlCustomParameters
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class GetauthorizationurlCustomParameters {
   @SerializedName("param1")
   private String param1 = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectAccessTokenParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectAccessTokenParams.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * IntrospectAccessTokenParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class IntrospectAccessTokenParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectAccessTokenResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectAccessTokenResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * IntrospectAccessTokenResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class IntrospectAccessTokenResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectAccessTokenResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectAccessTokenResponseData.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * IntrospectAccessTokenResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class IntrospectAccessTokenResponseData {
   @SerializedName("active")
   private Boolean active = null;
@@ -71,6 +71,15 @@ public class IntrospectAccessTokenResponseData {
 
   @SerializedName("extension_field")
   private String extensionField = null;
+
+  @SerializedName("error")
+  private String error = null;
+
+  @SerializedName("errorDescription")
+  private String errorDescription = null;
+
+  @SerializedName("details")
+  private Object details = null;
 
   public IntrospectAccessTokenResponseData active(Boolean active) {
     this.active = active;
@@ -334,6 +343,60 @@ public class IntrospectAccessTokenResponseData {
     this.extensionField = extensionField;
   }
 
+  public IntrospectAccessTokenResponseData error(String error) {
+    this.error = error;
+    return this;
+  }
+
+   /**
+   * Get error
+   * @return error
+  **/
+  @ApiModelProperty(value = "")
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+
+  public IntrospectAccessTokenResponseData errorDescription(String errorDescription) {
+    this.errorDescription = errorDescription;
+    return this;
+  }
+
+   /**
+   * Get errorDescription
+   * @return errorDescription
+  **/
+  @ApiModelProperty(value = "")
+  public String getErrorDescription() {
+    return errorDescription;
+  }
+
+  public void setErrorDescription(String errorDescription) {
+    this.errorDescription = errorDescription;
+  }
+
+  public IntrospectAccessTokenResponseData details(Object details) {
+    this.details = details;
+    return this;
+  }
+
+   /**
+   * Get details
+   * @return details
+  **/
+  @ApiModelProperty(value = "")
+  public Object getDetails() {
+    return details;
+  }
+
+  public void setDetails(Object details) {
+    this.details = details;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -357,12 +420,15 @@ public class IntrospectAccessTokenResponseData {
         Objects.equals(this.nbf, introspectAccessTokenResponseData.nbf) &&
         Objects.equals(this.jti, introspectAccessTokenResponseData.jti) &&
         Objects.equals(this.acrValues, introspectAccessTokenResponseData.acrValues) &&
-        Objects.equals(this.extensionField, introspectAccessTokenResponseData.extensionField);
+        Objects.equals(this.extensionField, introspectAccessTokenResponseData.extensionField) &&
+        Objects.equals(this.error, introspectAccessTokenResponseData.error) &&
+        Objects.equals(this.errorDescription, introspectAccessTokenResponseData.errorDescription) &&
+        Objects.equals(this.details, introspectAccessTokenResponseData.details);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(active, clientId, username, scope, tokenType, sub, aud, iss, exp, iat, nbf, jti, acrValues, extensionField);
+    return Objects.hash(active, clientId, username, scope, tokenType, sub, aud, iss, exp, iat, nbf, jti, acrValues, extensionField, error, errorDescription, details);
   }
 
 
@@ -385,6 +451,9 @@ public class IntrospectAccessTokenResponseData {
     sb.append("    jti: ").append(toIndentedString(jti)).append("\n");
     sb.append("    acrValues: ").append(toIndentedString(acrValues)).append("\n");
     sb.append("    extensionField: ").append(toIndentedString(extensionField)).append("\n");
+    sb.append("    error: ").append(toIndentedString(error)).append("\n");
+    sb.append("    errorDescription: ").append(toIndentedString(errorDescription)).append("\n");
+    sb.append("    details: ").append(toIndentedString(details)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectRptParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectRptParams.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * IntrospectRptParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class IntrospectRptParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectRptResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectRptResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * IntrospectRptResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class IntrospectRptResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectRptResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/IntrospectRptResponseData.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * IntrospectRptResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class IntrospectRptResponseData {
   @SerializedName("active")
   private Boolean active = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteParams.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * RegisterSiteParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class RegisterSiteParams {
   @SerializedName("authorization_redirect_uri")
   private String authorizationRedirectUri = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * RegisterSiteResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class RegisterSiteResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * RegisterSiteResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class RegisterSiteResponseData {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RemoveSiteParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RemoveSiteParams.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * RemoveSiteParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class RemoveSiteParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RemoveSiteResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RemoveSiteResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * RemoveSiteResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class RemoveSiteResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RemoveSiteResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RemoveSiteResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * RemoveSiteResponseData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-28T04:42:49.936Z")
 public class RemoveSiteResponseData {
   @SerializedName("oxd_id")
   private String oxdId = null;
@@ -49,7 +49,7 @@ public class RemoveSiteResponseData {
    * Get oxdId
    * @return oxdId
   **/
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(example = "bcad760f-91ba-46e1-a020-05e4281d91b6", required = true, value = "")
   public String getOxdId() {
     return oxdId;
   }

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RemoveSiteResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RemoveSiteResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * RemoveSiteResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class RemoveSiteResponseData {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetClaimsGatheringUrlParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetClaimsGatheringUrlParams.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UmaRpGetClaimsGatheringUrlParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRpGetClaimsGatheringUrlParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetClaimsGatheringUrlResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetClaimsGatheringUrlResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * UmaRpGetClaimsGatheringUrlResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRpGetClaimsGatheringUrlResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetClaimsGatheringUrlResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetClaimsGatheringUrlResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UmaRpGetClaimsGatheringUrlResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRpGetClaimsGatheringUrlResponseData {
   @SerializedName("url")
   private String url = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetRptParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetRptParams.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * UmaRpGetRptParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRpGetRptParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetRptResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetRptResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * UmaRpGetRptResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRpGetRptResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetRptResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRpGetRptResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UmaRpGetRptResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRpGetRptResponseData {
   @SerializedName("pct")
   private String pct = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsCheckAccessParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsCheckAccessParams.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UmaRsCheckAccessParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRsCheckAccessParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsCheckAccessResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsCheckAccessResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * UmaRsCheckAccessResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRsCheckAccessResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsCheckAccessResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsCheckAccessResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UmaRsCheckAccessResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRsCheckAccessResponseData {
   @SerializedName("access")
   private String access = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsProtectParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsProtectParams.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * UmaRsProtectParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRsProtectParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsProtectResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsProtectResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * UmaRsProtectResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRsProtectResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsProtectResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UmaRsProtectResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UmaRsProtectResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UmaRsProtectResponseData {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteParams.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * UpdateSiteParams
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UpdateSiteParams {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteResponse.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * UpdateSiteResponse
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UpdateSiteResponse {
   @SerializedName("status")
   private String status = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UpdateSiteResponseData
  */
-
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
 public class UpdateSiteResponseData {
   @SerializedName("oxd_id")
   private String oxdId = null;

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteResponseData.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteResponseData.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * UpdateSiteResponseData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-25T11:06:36.041Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-09-28T04:42:49.936Z")
 public class UpdateSiteResponseData {
   @SerializedName("oxd_id")
   private String oxdId = null;
@@ -49,7 +49,7 @@ public class UpdateSiteResponseData {
    * Get oxdId
    * @return oxdId
   **/
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(example = "bcad760f-91ba-46e1-a020-05e4281d91b6", required = true, value = "")
   public String getOxdId() {
     return oxdId;
   }

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
@@ -126,9 +126,8 @@ public class IntrospectAccessTokenTest extends BaseTestCase {
         assertEquals(apiIatResponse.getStatusCode(), 200);
         assertNotNull(apiIatResponse.getData());
         assertTrue("error".equalsIgnoreCase(apiIatResponse.getData().getStatus()));
-        IntrospectAccessTokenResponseData responseData = apiIatResponse.getData().getData();
-        assertNotNull(responseData);
-        assertTrue(responseData.getError().equals(ErrorResponseCode.INVALID_ID_TOKEN_MISMATCHED_CLIENT_ID.getCode()));
+        assertNotNull(apiIatResponse.getData().getData());
+        assertTrue(apiIatResponse.getData().getData().getError().equals(ErrorResponseCode.INVALID_ACCESS_TOKEN_MISMATCHED_CLIENT_ID.getCode()));
     }
 
     private static GetClientTokenResponseData getGetClientTokenResponseData(String opHost, DevelopersApi client,

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RemoveSiteTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RemoveSiteTest.java
@@ -49,7 +49,7 @@ public class RemoveSiteTest {
     }
 
     /**
-     * Method to test functionality using an ID token other than the one associated with registered site
+     * Method to test functionality using an access token other than the one associated with registered site
      */
     @ProtectionAccessTokenRequired
     @Test

--- a/oxd-server/src/main/java/org/xdi/oxd/server/service/ValidationService.java
+++ b/oxd-server/src/main/java/org/xdi/oxd/server/service/ValidationService.java
@@ -122,7 +122,7 @@ public class ValidationService {
         }
 
         if (!introspectionResponse.getClientId().equals(rp.getClientId())) {
-            throw new ErrorResponseException(ErrorResponseCode.INVALID_ID_TOKEN_MISMATCHED_CLIENT_ID);
+            throw new ErrorResponseException(ErrorResponseCode.INVALID_ACCESS_TOKEN_MISMATCHED_CLIENT_ID);
         }
         return true;
     }

--- a/oxd-server/src/main/java/org/xdi/oxd/server/service/ValidationService.java
+++ b/oxd-server/src/main/java/org/xdi/oxd/server/service/ValidationService.java
@@ -121,10 +121,10 @@ public class ValidationService {
             throw new ErrorResponseException(ErrorResponseCode.PROTECTION_ACCESS_TOKEN_INSUFFICIENT_SCOPE);
         }
 
-        if (introspectionResponse.getClientId().equals(rp.getClientId())) {
-            return true;
+        if (!introspectionResponse.getClientId().equals(rp.getClientId())) {
+            throw new ErrorResponseException(ErrorResponseCode.INVALID_ID_TOKEN_MISMATCHED_CLIENT_ID);
         }
-        throw new ErrorResponseException(ErrorResponseCode.INVALID_PROTECTION_ACCESS_TOKEN);
+        return true;
     }
 
     public IntrospectionResponse introspect(String accessToken, String oxdId) {

--- a/oxd-server/src/main/resources/swagger.yaml
+++ b/oxd-server/src/main/resources/swagger.yaml
@@ -166,74 +166,7 @@ paths:
                 type: string
                 example: ok
               data:
-                type: object
-                required:
-                  - active
-                  - client_id
-                  - username
-                  - scope
-                  - token_type
-                  - sub
-                  - aud
-                  - iss
-                  - exp
-                  - iat
-                  - acr_values
-                  - extension_field
-                  - nbf
-                  - jti
-                properties:
-                  active:
-                    type: boolean
-                    example: true
-                  client_id:
-                    type: string
-                    example: '@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.5F14.B387'
-                  username:
-                    type: string
-                    example: John Black
-                  scope:
-                    type: array
-                    items:
-                      type: string
-                  token_type:
-                    type: string
-                    example: bearer
-                  sub:
-                    type: string
-                    example: jblack
-                  aud:
-                    type: string
-                    example: l238j323ds-23ij4
-                  iss:
-                    type: string
-                    example: https://as.gluu.org/
-                  exp:
-                    type: integer
-                    format: int64
-                    description: number of seconds since January 1 1970 UTC, indicating when this token will expire
-                    example: 1535709072
-                  iat:
-                    type: integer
-                    format: int64
-                    description: number of seconds since January 1 1970 UTC, indicating when the token was issued at
-                    example: 1535709072
-                  nbf:
-                    type: integer
-                    format: int64
-                    description: number of seconds since January 1 1970 UTC, indicating when the token not to be used before
-                    example: 1535709072
-                  jti:
-                    type: string
-                    description: a unique identifier for the JWT
-                  acr_values:
-                    type: array
-                    items:
-                      type: string
-                    example: ["basic"]
-                  extension_field:
-                    type: string
-                    example: twenty-seven
+                $ref: "#/definitions/IntrospectAccessTokenResponseData"
         400:
           description: Invalid parameters are provided to endpoint.
         403:
@@ -1365,7 +1298,7 @@ definitions:
   # List of reusable properties
   oxd_id:
     type: string
-    example: bcad760f-91ba-46e1-a020-05e4281d91b6
+    example: 'bcad760f-91ba-46e1-a020-05e4281d91b6'
 
   # Schemas
   UpdateSiteResponseData:
@@ -1395,4 +1328,81 @@ definitions:
         type: string
       details:
         type: object
+
+  IntrospectAccessTokenResponseData:
+    type: object
+    required:
+    - active
+    - client_id
+    - username
+    - scope
+    - token_type
+    - sub
+    - aud
+    - iss
+    - exp
+    - iat
+    - acr_values
+    - extension_field
+    - nbf
+    - jti
+    properties:
+      active:
+        type: boolean
+        example: true
+      client_id:
+        type: string
+        example: '@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.5F14.B387'
+      username:
+        type: string
+        example: John Black
+      scope:
+        type: array
+        items:
+          type: string
+      token_type:
+        type: string
+        example: bearer
+      sub:
+        type: string
+        example: jblack
+      aud:
+        type: string
+        example: l238j323ds-23ij4
+      iss:
+        type: string
+        example: https://as.gluu.org/
+      exp:
+        type: integer
+        format: int64
+        description: number of seconds since January 1 1970 UTC, indicating when this token will expire
+        example: 1535709072
+      iat:
+        type: integer
+        format: int64
+        description: number of seconds since January 1 1970 UTC, indicating when the token was issued at
+        example: 1535709072
+      nbf:
+        type: integer
+        format: int64
+        description: number of seconds since January 1 1970 UTC, indicating when the token not to be used before
+        example: 1535709072
+      jti:
+        type: string
+        description: a unique identifier for the JWT
+      acr_values:
+        type: array
+        items:
+          type: string
+        example: ["basic"]
+      extension_field:
+        type: string
+        example: twenty-seven
+      error:
+        type: string
+      errorDescription:
+        type: string
+      details:
+        type: object
+
 

--- a/oxd-server/src/main/resources/swagger.yaml
+++ b/oxd-server/src/main/resources/swagger.yaml
@@ -1295,10 +1295,6 @@ paths:
           description: Internal error occured. Please check oxd-server.log file for details (usually located in /var/log/oxd-server/oxd-server.log).
 
 definitions:
-  # List of reusable properties
-  oxd_id:
-    type: string
-    example: 'bcad760f-91ba-46e1-a020-05e4281d91b6'
 
   # Schemas
   UpdateSiteResponseData:
@@ -1307,7 +1303,8 @@ definitions:
     - oxd_id
     properties:
       oxd_id:
-        $ref: "#/definitions/oxd_id"
+        type: string
+        example: bcad760f-91ba-46e1-a020-05e4281d91b6
       error:
         type: string
       errorDescription:
@@ -1321,7 +1318,8 @@ definitions:
     - oxd_id
     properties:
       oxd_id:
-        $ref: "#/definitions/oxd_id"
+        type: string
+        example: bcad760f-91ba-46e1-a020-05e4281d91b6
       error:
         type: string
       errorDescription:

--- a/oxd-server/src/test/java/org/xdi/oxd/server/IntrospectAccessTokenTest.java
+++ b/oxd-server/src/test/java/org/xdi/oxd/server/IntrospectAccessTokenTest.java
@@ -13,7 +13,7 @@ import org.xdi.oxd.common.response.GetClientTokenResponse;
 import org.xdi.oxd.common.response.RegisterSiteResponse;
 
 import static junit.framework.Assert.*;
-import static org.xdi.oxd.common.ErrorResponseCode.INVALID_ID_TOKEN_MISMATCHED_CLIENT_ID;
+import static org.xdi.oxd.common.ErrorResponseCode.INVALID_ACCESS_TOKEN_MISMATCHED_CLIENT_ID;
 import static org.xdi.oxd.server.TestUtils.notEmpty;
 
 /**
@@ -80,7 +80,7 @@ public class IntrospectAccessTokenTest {
 
         ErrorResponse introspectionResponse = client.introspectAccessToken("Bearer " + tokenResponse.getAccessToken(), iatParams).dataAsResponse(ErrorResponse.class);
         assertNotNull(introspectionResponse);
-        assertEquals(introspectionResponse.getError(), INVALID_ID_TOKEN_MISMATCHED_CLIENT_ID.getCode());
+        assertEquals(introspectionResponse.getError(), INVALID_ACCESS_TOKEN_MISMATCHED_CLIENT_ID.getCode());
 
     }
 }

--- a/oxd-server/src/test/java/org/xdi/oxd/server/Tester.java
+++ b/oxd-server/src/test/java/org/xdi/oxd/server/Tester.java
@@ -62,4 +62,8 @@ public class Tester {
         HOST = host;
         OP_HOST = opHost;
     }
+
+    public static RegisterSiteResponse getSetupData() {
+        return SETUP_CLIENT;
+    }
 }


### PR DESCRIPTION
Server now returns a mismatched client id exception if a different token is passed other than the one associated with the client. Both swagger and non swagger tests have been updated accordingly.