### PR TITLE
Issue#280

### DIFF
--- a/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
@@ -255,7 +255,7 @@ public class Cli {
             }
             printHelpAndExit();
         } catch (Exception e) {
-            System.out.println("Failed to execute command against oxd-server on port " + port + ". Check if correct access_token passed with -a parameter, error: " + e.getMessage());
+            System.out.println("Failed to execute command against oxd-server on port " + port + ". Check if correct access_token is passed with -a parameter, error: " + e.getMessage());
             e.printStackTrace();
             System.exit(1);
         }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
@@ -33,10 +33,7 @@ import org.gluu.util.Pair;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * @author yuriyz
@@ -64,12 +61,15 @@ public class Cli {
 
             //check multiple options
             if(Cli.checkForMultipleOptions(cmd)) {
-                System.out.println("Multiple options in command is not allowed.");
+                System.out.println("Multiple parameters in command is not allowed.");
                 printHelpAndExit();
                 return;
             }
             // list
             if (cmd.hasOption("l")) {
+                if(Cli.checkForArgsAfterListParameter(args)){
+                    System.out.println("Arguments after list parameter is not required, hence will be ignored.");
+                }
                 final Collection<Rp> values = rpService.getRps().values();
                 if (values.isEmpty()) {
                     System.out.println("There are no any entries yet in database.");
@@ -315,6 +315,17 @@ public class Cli {
             return true;
         else
             return false;
+    }
+
+    private static boolean checkForArgsAfterListParameter(String[] args){
+
+        String[] parameterList = {"-d", "-oxd_id", "-a"};
+        int listIndex = Arrays.asList(args).indexOf("-l");
+
+        if((args.length-1) > listIndex){
+            return !(Arrays.stream(parameterList).anyMatch(args[listIndex+1]::equals));
+        }
+        return false;
     }
 
 }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
@@ -62,6 +62,12 @@ public class Cli {
             RpService rpService = injector.getInstance(RpService.class);
             rpService.load();
 
+            //check multiple options
+            if(Cli.checkForMultipleOptions(cmd)) {
+                System.out.println("Multiple options in command is not allowed.");
+                printHelpAndExit();
+                return;
+            }
             // list
             if (cmd.hasOption("l")) {
                 final Collection<Rp> values = rpService.getRps().values();
@@ -249,7 +255,7 @@ public class Cli {
             }
             printHelpAndExit();
         } catch (Exception e) {
-            System.out.println("Failed to execute command against oxd-server on port " + port + ", error: " + e.getMessage());
+            System.out.println("Failed to execute command against oxd-server on port " + port + ". Check if access_token passed with -a parameter is correct, error: " + e.getMessage());
             e.printStackTrace();
             System.exit(1);
         }
@@ -293,4 +299,24 @@ public class Cli {
 
         return options;
     }
+
+    private static boolean checkForMultipleOptions(CommandLine cmd){
+        int optionsCount = 0;
+        if (cmd.hasOption("l")) {
+            optionsCount ++;
+        }
+        if (cmd.hasOption("oxd_id")) {
+            optionsCount ++;
+        }
+        if (cmd.hasOption("d")) {
+            optionsCount ++;
+        }
+        if(optionsCount > 1)
+            return true;
+        else
+            return false;
+    }
+
 }
+
+

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
@@ -60,15 +60,15 @@ public class Cli {
             rpService.load();
 
             //check multiple options
-            if(Cli.checkForMultipleOptions(cmd)) {
+            if(hasMultipleActionOptions(cmd)) {
                 System.out.println("Multiple parameters in command is not allowed.");
                 printHelpAndExit();
                 return;
             }
             // list
             if (cmd.hasOption("l")) {
-                if(Cli.checkForArgsAfterListParameter(args)){
-                    System.out.println("Arguments after list parameter is not required, hence will be ignored.");
+                if(hasListParameterValue(args)) {
+                    System.out.println("Warning: Arguments after list parameter is not required, hence will be ignored.");
                 }
                 final Collection<Rp> values = rpService.getRps().values();
                 if (values.isEmpty()) {
@@ -255,7 +255,7 @@ public class Cli {
             }
             printHelpAndExit();
         } catch (Exception e) {
-            System.out.println("Failed to execute command against oxd-server on port " + port + ". Check if correct access_token is passed with -a parameter, error: " + e.getMessage());
+            System.out.println("Failed to execute command against oxd-server on port " + port + ". Please check oxd_id or access_token really exists and is not malformed, error: " + e.getMessage());
             e.printStackTrace();
             System.exit(1);
         }
@@ -300,7 +300,7 @@ public class Cli {
         return options;
     }
 
-    private static boolean checkForMultipleOptions(CommandLine cmd){
+    private static boolean hasMultipleActionOptions(CommandLine cmd) {
         int optionsCount = 0;
         if (cmd.hasOption("l")) {
             optionsCount ++;
@@ -311,19 +311,21 @@ public class Cli {
         if (cmd.hasOption("d")) {
             optionsCount ++;
         }
-        if(optionsCount > 1)
+        if(optionsCount > 1) {
             return true;
-        else
+        } else {
             return false;
+        }
     }
 
-    private static boolean checkForArgsAfterListParameter(String[] args){
+    private static boolean hasListParameterValue(String[] args) {
+        List<Option> options = new ArrayList<>(options().getOptions());
+        options.remove(options().getOption("l"));
 
-        String[] parameterList = {"-d", "-oxd_id", "-a"};
         int listIndex = Arrays.asList(args).indexOf("-l");
 
-        if((args.length-1) > listIndex){
-            return !(Arrays.stream(parameterList).anyMatch(args[listIndex+1]::equals));
+        if((args.length-1) > listIndex) {
+            return !options.stream().anyMatch(opt -> "-".concat(opt.getOpt()).equals(args[listIndex+1]));
         }
         return false;
     }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Cli.java
@@ -255,7 +255,7 @@ public class Cli {
             }
             printHelpAndExit();
         } catch (Exception e) {
-            System.out.println("Failed to execute command against oxd-server on port " + port + ". Check if access_token passed with -a parameter is correct, error: " + e.getMessage());
+            System.out.println("Failed to execute command against oxd-server on port " + port + ". Check if correct access_token passed with -a parameter, error: " + e.getMessage());
             e.printStackTrace();
             System.exit(1);
         }

--- a/oxd-server/src/main/resources/oxd-server.yml
+++ b/oxd-server/src/main/resources/oxd-server.yml
@@ -66,3 +66,4 @@ defaultSiteConfig:
   ui_locales: ['en']
   claims_locales: ['en']
   contacts: []
+

--- a/oxd-server/src/main/resources/oxd-server.yml
+++ b/oxd-server/src/main/resources/oxd-server.yml
@@ -66,4 +66,3 @@ defaultSiteConfig:
   ui_locales: ['en']
   claims_locales: ['en']
   contacts: []
-


### PR DESCRIPTION
This PR contains fix for below 2 issues.

#280 - NPE while using lsox script
https://github.com/GluuFederation/oxd/issues/280

#281 - Invalid token accepted while using lsox script
https://github.com/GluuFederation/oxd/issues/281

Changes Done
-----------------
1. In this fix "checkForMultipleOptions" method is added to restrict execution of script if multiple parameters (like sh lsox.sh -l -oxd_id ssgkdju374v3vnn -a vevve3e) are entered.
2. Another method "checkForArgsAfterListParameter" have been also added to print message "Arguments after list parameter is not required, hence will be ignored." in case arguments are provided to -l parameter.
3.  If access token after -a parameter is incorrect then it throws an error. We have added following line to error message to point the acutal cause of error - "Check if correct access_token is passed with -a parameter".
