### PR TITLE
#308 - GG request : add `authorization_redirect_uri` parameter suppor…

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
@@ -69,7 +69,7 @@ public enum ErrorResponseCode {
     FAILED_TO_GET_END_SESSION_ENDPOINT(500, "no_end_session_endpoint_at_op", "OP does not provide end_session_endpoint at /.well-known/openid-configuration."),
     FAILED_TO_GET_RPT(500, "internal_error", "Failed to get RPT."),
     FAILED_TO_REMOVE_SITE(500, "remove_site_failed", "Failed to remove site."),
-    REDIRECT_URI_IS_NOT_REGISTERED(500, "redirect_uri_is_not_registered", "The authentication redirect uri is not registered.");
+    REDIRECT_URI_IS_NOT_REGISTERED(400, "redirect_uri_is_not_registered", "The authorization redirect uri is not registered.");
 
     private final int httpStatus;
     private final String code;

--- a/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
@@ -68,8 +68,8 @@ public enum ErrorResponseCode {
     UMA_PROTECTION_FAILED_BECAUSE_RESOURCES_ALREADY_EXISTS(400, "uma_protection_exists", "Server already has UMA Resources registered for this oxd_id. It is possible to overwrite it if provide overwrite=true for uma_rs_protect command (existing resources will be removed and new UMA Resources added)."),
     FAILED_TO_GET_END_SESSION_ENDPOINT(500, "no_end_session_endpoint_at_op", "OP does not provide end_session_endpoint at /.well-known/openid-configuration."),
     FAILED_TO_GET_RPT(500, "internal_error", "Failed to get RPT."),
-    FAILED_TO_REMOVE_SITE(500, "remove_site_failed", "Failed to remove site.");
-
+    FAILED_TO_REMOVE_SITE(500, "remove_site_failed", "Failed to remove site."),
+    REDIRECT_URI_IS_NOT_REGISTERED(500, "redirect_uri_is_not_registered", "The authentication redirect uri is not registered.");
 
     private final int httpStatus;
     private final String code;

--- a/oxd-common/src/main/java/org/gluu/oxd/common/params/GetAuthorizationUrlParams.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/params/GetAuthorizationUrlParams.java
@@ -28,6 +28,8 @@ public class GetAuthorizationUrlParams implements HasProtectionAccessTokenParams
     private String protection_access_token;
     @JsonProperty(value = "custom_parameters")
     private Map<String, String> custom_parameters;
+    @JsonProperty(value = "authorization_redirect_uri")
+    private String authorization_redirect_uri;
 
     public GetAuthorizationUrlParams() {
     }
@@ -88,6 +90,14 @@ public class GetAuthorizationUrlParams implements HasProtectionAccessTokenParams
         this.acr_values = acrValues;
     }
 
+    public String getAuthorizationRedirectUri() {
+        return authorization_redirect_uri;
+    }
+
+    public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
+        this.authorization_redirect_uri = authorizationRedirectUri;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -116,6 +126,7 @@ public class GetAuthorizationUrlParams implements HasProtectionAccessTokenParams
                 ", hd='" + hd + '\'' +
                 ", protection_access_token='" + protection_access_token + '\'' +
                 ", custom_parameters=" + custom_parameters +
+                ", authorization_redirect_uri=" + authorization_redirect_uri +
                 '}';
     }
 }

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlParams.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 /**
  * GetAuthorizationUrlParams
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-03-15T09:55:53.588Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-17T12:08:18.906Z")
 public class GetAuthorizationUrlParams {
   @SerializedName("oxd_id")
   private String oxdId = null;
@@ -36,6 +36,9 @@ public class GetAuthorizationUrlParams {
 
   @SerializedName("prompt")
   private String prompt = null;
+
+  @SerializedName("authorization_redirect_uri")
+  private String authorizationRedirectUri = null;
 
   @SerializedName("custom_parameters")
   private GetauthorizationurlCustomParameters customParameters = null;
@@ -128,6 +131,24 @@ public class GetAuthorizationUrlParams {
     this.prompt = prompt;
   }
 
+  public GetAuthorizationUrlParams authorizationRedirectUri(String authorizationRedirectUri) {
+    this.authorizationRedirectUri = authorizationRedirectUri;
+    return this;
+  }
+
+  /**
+   * Get authorizationRedirectUri
+   * @return authorizationRedirectUri
+   **/
+  @ApiModelProperty(example = "https://client.example.org/cb", value = "")
+  public String getAuthorizationRedirectUri() {
+    return authorizationRedirectUri;
+  }
+
+  public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
+    this.authorizationRedirectUri = authorizationRedirectUri;
+  }
+
   public GetAuthorizationUrlParams customParameters(GetauthorizationurlCustomParameters customParameters) {
     this.customParameters = customParameters;
     return this;
@@ -157,15 +178,16 @@ public class GetAuthorizationUrlParams {
     }
     GetAuthorizationUrlParams getAuthorizationUrlParams = (GetAuthorizationUrlParams) o;
     return Objects.equals(this.oxdId, getAuthorizationUrlParams.oxdId) &&
-        Objects.equals(this.scope, getAuthorizationUrlParams.scope) &&
-        Objects.equals(this.acrValues, getAuthorizationUrlParams.acrValues) &&
-        Objects.equals(this.prompt, getAuthorizationUrlParams.prompt) &&
-        Objects.equals(this.customParameters, getAuthorizationUrlParams.customParameters);
+            Objects.equals(this.scope, getAuthorizationUrlParams.scope) &&
+            Objects.equals(this.acrValues, getAuthorizationUrlParams.acrValues) &&
+            Objects.equals(this.prompt, getAuthorizationUrlParams.prompt) &&
+            Objects.equals(this.authorizationRedirectUri, getAuthorizationUrlParams.authorizationRedirectUri) &&
+            Objects.equals(this.customParameters, getAuthorizationUrlParams.customParameters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(oxdId, scope, acrValues, prompt, customParameters);
+    return Objects.hash(oxdId, scope, acrValues, prompt, authorizationRedirectUri, customParameters);
   }
 
 
@@ -173,11 +195,12 @@ public class GetAuthorizationUrlParams {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class GetAuthorizationUrlParams {\n");
-    
+
     sb.append("    oxdId: ").append(toIndentedString(oxdId)).append("\n");
     sb.append("    scope: ").append(toIndentedString(scope)).append("\n");
     sb.append("    acrValues: ").append(toIndentedString(acrValues)).append("\n");
     sb.append("    prompt: ").append(toIndentedString(prompt)).append("\n");
+    sb.append("    authorizationRedirectUri: ").append(toIndentedString(authorizationRedirectUri)).append("\n");
     sb.append("    customParameters: ").append(toIndentedString(customParameters)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Utils.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Utils.java
@@ -97,13 +97,4 @@ public class Utils {
     public static List<String> stringToList(String source) {
         return Arrays.asList(source.split("\\s+"));
     }
-
-    public static boolean hasAuthorizationRedirectUri(List<String> redirectUris, String authorizationRedirectUri) {
-        if (!redirectUris.isEmpty() && authorizationRedirectUri != null) {
-            if (redirectUris.contains(authorizationRedirectUri)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Utils.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Utils.java
@@ -97,4 +97,13 @@ public class Utils {
     public static List<String> stringToList(String source) {
         return Arrays.asList(source.split("\\s+"));
     }
+
+    public static boolean hasAuthorizationRedirectUri(List<String> redirectUris, String authorizationRedirectUri) {
+        if (!redirectUris.isEmpty() && authorizationRedirectUri != null) {
+            if (redirectUris.contains(authorizationRedirectUri)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/oxd-server/src/main/resources/swagger.yaml
+++ b/oxd-server/src/main/resources/swagger.yaml
@@ -591,6 +591,9 @@ paths:
                 example: ["basic"]
               prompt:
                 type: string
+              authorization_redirect_uri:
+                type: string
+                example: https://client.example.org/cb
               custom_parameters:
                 type: object
                 required:

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetAuthorizationUrlTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetAuthorizationUrlTest.java
@@ -7,6 +7,8 @@ import org.gluu.oxd.common.params.GetAuthorizationUrlParams;
 import org.gluu.oxd.common.response.GetAuthorizationUrlResponse;
 import org.gluu.oxd.common.response.RegisterSiteResponse;
 
+import java.io.IOException;
+
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
@@ -25,6 +27,20 @@ public class GetAuthorizationUrlTest {
         final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
         commandParams.setOxdId(site.getOxdId());
 
+        final GetAuthorizationUrlResponse resp = client.getAuthorizationUrl(Tester.getAuthorization(), commandParams);
+        assertNotNull(resp);
+        notEmpty(resp.getAuthorizationUrl());
+    }
+
+    @Parameters({"host", "redirectUrl", "opHost", "redirectUrls", "postLogoutRedirectUrl", "logoutUrl", "paramRedirectUrl"})
+    @Test
+    public void testWithParameterAuthorizationUrl(String host, String redirectUrl, String opHost, String redirectUrls, String postLogoutRedirectUrl, String logoutUrl, String paramRedirectUrl) throws IOException {
+        ClientInterface client = Tester.newClient(host);
+
+        final RegisterSiteResponse site = RegisterSiteTest.registerWithMultipleRedirectUrls(client, opHost, redirectUrl, postLogoutRedirectUrl, logoutUrl, redirectUrls);
+        final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
+        commandParams.setOxdId(site.getOxdId());
+        commandParams.setAuthorizationRedirectUri(paramRedirectUrl);
         final GetAuthorizationUrlResponse resp = client.getAuthorizationUrl(Tester.getAuthorization(), commandParams);
         assertNotNull(resp);
         notEmpty(resp.getAuthorizationUrl());

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetAuthorizationUrlTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetAuthorizationUrlTest.java
@@ -1,16 +1,18 @@
 package org.gluu.oxd.server;
 
+import org.apache.commons.lang.StringUtils;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.gluu.oxd.client.ClientInterface;
 import org.gluu.oxd.common.params.GetAuthorizationUrlParams;
 import org.gluu.oxd.common.response.GetAuthorizationUrlResponse;
 import org.gluu.oxd.common.response.RegisterSiteResponse;
+import com.google.common.collect.Lists;
 
 import java.io.IOException;
-
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Yuriy Zabrovarnyy
@@ -37,12 +39,16 @@ public class GetAuthorizationUrlTest {
     public void testWithParameterAuthorizationUrl(String host, String redirectUrl, String opHost, String redirectUrls, String postLogoutRedirectUrl, String logoutUrl, String paramRedirectUrl) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerWithMultipleRedirectUrls(client, opHost, redirectUrl, postLogoutRedirectUrl, logoutUrl, redirectUrls);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl, postLogoutRedirectUrl, logoutUrl,
+                StringUtils.isNotBlank(redirectUrls) ? Lists.newArrayList(redirectUrls.split(" ")) : null);
         final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
         commandParams.setOxdId(site.getOxdId());
         commandParams.setAuthorizationRedirectUri(paramRedirectUrl);
+
         final GetAuthorizationUrlResponse resp = client.getAuthorizationUrl(Tester.getAuthorization(), commandParams);
         assertNotNull(resp);
         notEmpty(resp.getAuthorizationUrl());
+        assertTrue(resp.getAuthorizationUrl().contains(paramRedirectUrl));
+
     }
 }

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
@@ -14,6 +14,7 @@ import org.gluu.oxd.common.response.UpdateSiteResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
@@ -31,7 +32,7 @@ public class RegisterSiteTest {
     @Parameters({"host", "opHost", "redirectUrl", "logoutUrl", "postLogoutRedirectUrl"})
     @Test
     public void register(String host, String opHost, String redirectUrl, String postLogoutRedirectUrl, String logoutUrl) throws IOException {
-        RegisterSiteResponse resp = registerSite(Tester.newClient(host), opHost, redirectUrl, postLogoutRedirectUrl, logoutUrl);
+        RegisterSiteResponse resp = registerSite(Tester.newClient(host), opHost, redirectUrl, postLogoutRedirectUrl, logoutUrl, null);
         assertNotNull(resp);
 
         notEmpty(resp.getOxdId());
@@ -73,16 +74,21 @@ public class RegisterSiteTest {
     }
 
     public static RegisterSiteResponse registerSite(ClientInterface client, String opHost, String redirectUrl) {
-        return registerSite(client, opHost, redirectUrl, redirectUrl, "");
+        return registerSite(client, opHost, redirectUrl, redirectUrl, "", null);
     }
 
     public static RegisterSiteResponse registerSite(ClientInterface client, String opHost, String redirectUrl, String postLogoutRedirectUrl, String logoutUri) {
+        return registerSite(client, opHost, redirectUrl, postLogoutRedirectUrl, logoutUri, null);
+    }
+
+    public static RegisterSiteResponse registerSite(ClientInterface client, String opHost, String redirectUrl, String postLogoutRedirectUrl, String logoutUri, List<String> redirectUris) {
 
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
         params.setAuthorizationRedirectUri(redirectUrl);
         params.setPostLogoutRedirectUri(postLogoutRedirectUrl);
         params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUri));
+        params.setRedirectUris(redirectUris);
         params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
         params.setTrustedClient(true);
         params.setGrantTypes(Lists.newArrayList(
@@ -94,28 +100,5 @@ public class RegisterSiteTest {
         assertNotNull(resp);
         assertTrue(!Strings.isNullOrEmpty(resp.getOxdId()));
         return resp;
-    }
-
-    public static RegisterSiteResponse registerWithMultipleRedirectUrls(ClientInterface client, String opHost, String authorizationRedirectUrl, String postLogoutRedirectUrl, String logoutUrl, String redirectUrls) throws IOException {
-        final RegisterSiteParams params = new RegisterSiteParams();
-        params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(authorizationRedirectUrl);
-        params.setPostLogoutRedirectUri(postLogoutRedirectUrl);
-        params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUrl));
-        params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
-        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(",")));
-        params.setTrustedClient(true);
-        params.setPostLogoutRedirectUri(postLogoutRedirectUrl);
-        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(",")));
-        params.setGrantTypes(Lists.newArrayList(
-                GrantType.AUTHORIZATION_CODE.getValue(),
-                GrantType.OXAUTH_UMA_TICKET.getValue(),
-                GrantType.CLIENT_CREDENTIALS.getValue()));
-
-        final RegisterSiteResponse resp = client.registerSite(params);
-        assertNotNull(resp);
-        assertTrue(!Strings.isNullOrEmpty(resp.getOxdId()));
-        return resp;
-
     }
 }

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
@@ -95,4 +95,27 @@ public class RegisterSiteTest {
         assertTrue(!Strings.isNullOrEmpty(resp.getOxdId()));
         return resp;
     }
+
+    public static RegisterSiteResponse registerWithMultipleRedirectUrls(ClientInterface client, String opHost, String authorizationRedirectUrl, String postLogoutRedirectUrl, String logoutUrl, String redirectUrls) throws IOException {
+        final RegisterSiteParams params = new RegisterSiteParams();
+        params.setOpHost(opHost);
+        params.setAuthorizationRedirectUri(authorizationRedirectUrl);
+        params.setPostLogoutRedirectUri(postLogoutRedirectUrl);
+        params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUrl));
+        params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(",")));
+        params.setTrustedClient(true);
+        params.setPostLogoutRedirectUri(postLogoutRedirectUrl);
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(",")));
+        params.setGrantTypes(Lists.newArrayList(
+                GrantType.AUTHORIZATION_CODE.getValue(),
+                GrantType.OXAUTH_UMA_TICKET.getValue(),
+                GrantType.CLIENT_CREDENTIALS.getValue()));
+
+        final RegisterSiteResponse resp = client.registerSite(params);
+        assertNotNull(resp);
+        assertTrue(!Strings.isNullOrEmpty(resp.getOxdId()));
+        return resp;
+
+    }
 }

--- a/oxd-server/src/test/resources/testng.xml
+++ b/oxd-server/src/test/resources/testng.xml
@@ -5,7 +5,7 @@
     <parameter name="host" value="http://localhost"/>
     <parameter name="opHost" value="https://${test.server.name}"/>
     <parameter name="redirectUrl" value="https://client.example.com/cb"/>
-    <parameter name="redirectUrls" value="https://client.example.com/cb/home1,https://client.example.com/cb/home2"/>
+    <parameter name="redirectUrls" value="https://client.example.com/cb/home1 https://client.example.com/cb/home2"/>
     <parameter name="paramRedirectUrl" value="https://client.example.com/cb/home2"/>
     <parameter name="postLogoutRedirectUrl" value="https://client.example.com/cb/logout"/>
     <parameter name="logoutUrl" value="https://client.example.com/logout"/>

--- a/oxd-server/src/test/resources/testng.xml
+++ b/oxd-server/src/test/resources/testng.xml
@@ -5,6 +5,8 @@
     <parameter name="host" value="http://localhost"/>
     <parameter name="opHost" value="https://${test.server.name}"/>
     <parameter name="redirectUrl" value="https://client.example.com/cb"/>
+    <parameter name="redirectUrls" value="https://client.example.com/cb/home1,https://client.example.com/cb/home2"/>
+    <parameter name="paramRedirectUrl" value="https://client.example.com/cb/home2"/>
     <parameter name="postLogoutRedirectUrl" value="https://client.example.com/cb/logout"/>
     <parameter name="logoutUrl" value="https://client.example.com/logout"/>
     <parameter name="userId" value="${auth.user.uid}"/>


### PR DESCRIPTION
#308 - GG request : add `authorization_redirect_uri` parameter support to `/get-authorization-url` command
https://github.com/GluuFederation/oxd/issues/308


Changes done
----------------
 We have added 'authorization_redirect_uri' parameter in request body of '/get-authorization-url' end-point. The end-point will check if 'redirect_uri' (passed as parameter) is present in 'redirect_uris' list, in case it exists then it replace it as authorization_redirect_uri in h2 database and forms response of the end-point.

We have also added test cases to check above changes.