### PR TITLE
#332 - oxd-4.0: Remove redundant Logger-specific levels (`Trace`) from oxd-server.yml

### DIFF
--- a/oxd-server/src/main/resources/oxd-server.yml
+++ b/oxd-server/src/main/resources/oxd-server.yml
@@ -40,7 +40,6 @@ logging:
   # Logger-specific levels.
   loggers:
     org.gluu: TRACE
-    org.gluu: TRACE
 
 # Logback's Time Based Rolling Policy - archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}.log.gz
 # Logback's Size and Time Based Rolling Policy -  archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}-%i.log.gz

--- a/oxd-server/src/test/resources/oxd-server-dev.yml
+++ b/oxd-server/src/test/resources/oxd-server-dev.yml
@@ -45,7 +45,6 @@ logging:
   # Logger-specific levels.
   loggers:
     org.gluu: TRACE
-    org.gluu: TRACE
 
 # Logback's Time Based Rolling Policy - archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}.log.gz
 # Logback's Size and Time Based Rolling Policy -  archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}-%i.log.gz

--- a/oxd-server/src/test/resources/oxd-server-jenkins.yml
+++ b/oxd-server/src/test/resources/oxd-server-jenkins.yml
@@ -37,7 +37,6 @@ logging:
   # Logger-specific levels.
   loggers:
     org.gluu: TRACE
-    org.gluu: TRACE
 
 # Logback's Time Based Rolling Policy - archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}.log.gz
 # Logback's Size and Time Based Rolling Policy -  archivedLogFilenamePattern: /tmp/application-%d{yyyy-MM-dd}-%i.log.gz


### PR DESCRIPTION
#332 - oxd-4.0: Remove redundant Logger-specific levels (`Trace`) from oxd-server.yml
https://github.com/GluuFederation/oxd/issues/332