### PR TITLE
#343 - Remove authorization_redirect_uri from /register-site command …

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
@@ -54,7 +54,7 @@ public enum ErrorResponseCode {
     INVALID_ACCESS_TOKEN(403, "invalid_access_token", "Invalid access_token. Command is protected by access_token, please provide valid token or otherwise switch off protection in configuration with protect_commands_with_access_token=false"),
     NO_CLIENT_ID_IN_INTROSPECTION_RESPONSE(500, "invalid_introspection_response", "AS returned introspection response with empty/blank client_id which is required by oxd. Please check your AS installation and make sure AS return client_id for introspection call (CE 3.1.0 or later)."),
     INACTIVE_ACCESS_TOKEN(403, "inactive_access_token", "Inactive access_token. Command is protected by access_token, please provide valid token or otherwise switch off protection in configuration with protect_commands_with_access_token=false"),
-    INVALID_AUTHORIZATION_REDIRECT_URI(400, "invalid_authorization_redirect_uri", "Invalid authorization_redirect_uri (empty or blank)."),
+    INVALID_REDIRECT_URI(400, "invalid_redirect_uri", "Invalid redirect_uri (empty, blank or invalid)."),
     INVALID_SCOPE(400, "invalid_scope", "Invalid scope parameter (empty or blank)."),
     INVALID_ACR_VALUES(400, "invalid_acr_values", "Invalid acr_values parameter (empty or blank)."),
     INVALID_SIGNATURE_ALGORITHM(400, "invalid_algorithm", "Invalid algorithm provided. Valid algorithms are: " + Arrays.toString(SignatureAlgorithm.values())),

--- a/oxd-common/src/main/java/org/gluu/oxd/common/params/GetAuthorizationUrlParams.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/params/GetAuthorizationUrlParams.java
@@ -32,8 +32,8 @@ public class GetAuthorizationUrlParams implements HasAccessTokenParams {
     private Map<String, String> custom_parameters;
     @JsonProperty(value = "params")
     private Map<String, String> params;
-    @JsonProperty(value = "authorization_redirect_uri")
-    private String authorization_redirect_uri;
+    @JsonProperty(value = "redirect_uri")
+    private String redirect_uri;
 
     public GetAuthorizationUrlParams() {
     }
@@ -94,14 +94,6 @@ public class GetAuthorizationUrlParams implements HasAccessTokenParams {
         this.acr_values = acrValues;
     }
 
-    public String getAuthorizationRedirectUri() {
-        return authorization_redirect_uri;
-    }
-
-    public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
-        this.authorization_redirect_uri = authorizationRedirectUri;
-    }
-
     public Map<String, String> getParams() {
         return params;
     }
@@ -116,6 +108,14 @@ public class GetAuthorizationUrlParams implements HasAccessTokenParams {
 
     public void setState(String state) {
         this.state = state;
+    }
+
+    public String getRedirectUri() {
+        return redirect_uri;
+    }
+
+    public void setRedirectUri(String redirectUri) {
+        this.redirect_uri = redirectUri;
     }
 
     @Override
@@ -147,7 +147,7 @@ public class GetAuthorizationUrlParams implements HasAccessTokenParams {
                 ", token='" + token + '\'' +
                 ", params=" + params +
                 ", custom_parameters=" + custom_parameters +
-                ", authorization_redirect_uri='" + authorization_redirect_uri + '\'' +
+                ", redirect_uri='" + redirect_uri + '\'' +
                 ", state='" + state + '\'' +
                 '}';
     }

--- a/oxd-common/src/main/java/org/gluu/oxd/common/params/RegisterSiteParams.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/params/RegisterSiteParams.java
@@ -17,8 +17,6 @@ public class RegisterSiteParams implements HasOxdIdParams {
     private String op_host;
     @JsonProperty(value = "op_discovery_path")
     private String op_discovery_path;
-    @JsonProperty(value = "authorization_redirect_uri")
-    private String authorization_redirect_uri;
     @JsonProperty(value = "post_logout_redirect_uris")
     private List<String> post_logout_redirect_uris;
     @JsonProperty(value = "redirect_uris")
@@ -27,7 +25,6 @@ public class RegisterSiteParams implements HasOxdIdParams {
     private List<String> response_types;
     @JsonProperty(value = "claims_redirect_uri")
     private List<String> claims_redirect_uri;
-
     @JsonProperty(value = "client_id")
     private String client_id;
     @JsonProperty(value = "client_secret")
@@ -258,14 +255,6 @@ public class RegisterSiteParams implements HasOxdIdParams {
 
     public void setClientJwksUri(String clientJwksUri) {
         this.client_jwks_uri = clientJwksUri;
-    }
-
-    public String getAuthorizationRedirectUri() {
-        return authorization_redirect_uri;
-    }
-
-    public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
-        this.authorization_redirect_uri = authorizationRedirectUri;
     }
 
     public List<String> getClaimsLocales() {
@@ -861,7 +850,6 @@ public class RegisterSiteParams implements HasOxdIdParams {
         return "RegisterSiteParams{" +
                 "op_host='" + op_host + '\'' +
                 ", op_discovery_path='" + op_discovery_path + '\'' +
-                ", authorization_redirect_uri='" + authorization_redirect_uri + '\'' +
                 ", post_logout_redirect_uris='" + post_logout_redirect_uris + '\'' +
                 ", redirect_uris=" + redirect_uris +
                 ", response_types=" + response_types +

--- a/oxd-common/src/main/java/org/gluu/oxd/common/params/UpdateSiteParams.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/params/UpdateSiteParams.java
@@ -15,8 +15,6 @@ public class UpdateSiteParams implements HasAccessTokenParams {
 
     @JsonProperty(value = "oxd_id")
     private String oxd_id;
-    @JsonProperty(value = "authorization_redirect_uri")
-    private String authorization_redirect_uri;
     @JsonProperty(value = "post_logout_redirect_uris")
     private List<String> post_logout_redirect_uris;
 
@@ -136,14 +134,6 @@ public class UpdateSiteParams implements HasAccessTokenParams {
         this.client_jwks_uri = clientJwksUri;
     }
 
-    public String getAuthorizationRedirectUri() {
-        return authorization_redirect_uri;
-    }
-
-    public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
-        this.authorization_redirect_uri = authorizationRedirectUri;
-    }
-
     public List<String> getClaimsLocales() {
         return claims_locales;
     }
@@ -246,7 +236,6 @@ public class UpdateSiteParams implements HasAccessTokenParams {
         sb.append("UpdateSiteParams");
         sb.append("{acr_values=").append(acr_values);
         sb.append(", oxd_id='").append(oxd_id).append('\'');
-        sb.append(", authorization_redirect_uri='").append(authorization_redirect_uri).append('\'');
         sb.append(", post_logout_redirect_uris='").append(post_logout_redirect_uris).append('\'');
         sb.append(", redirect_uris=").append(redirect_uris);
         sb.append(", response_types=").append(response_types);

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlParams.java
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  * GetAuthorizationUrlParams
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-28T07:12:55.225Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-07-11T13:31:30.809Z")
 public class GetAuthorizationUrlParams {
   @SerializedName("oxd_id")
   private String oxdId = null;
@@ -47,8 +47,8 @@ public class GetAuthorizationUrlParams {
   @SerializedName("state")
   private String state = null;
 
-  @SerializedName("authorization_redirect_uri")
-  private String authorizationRedirectUri = null;
+  @SerializedName("redirect_uri")
+  private String redirectUri = null;
 
   @SerializedName("custom_parameters")
   private GetauthorizationurlCustomParameters customParameters = null;
@@ -162,22 +162,22 @@ public class GetAuthorizationUrlParams {
     this.state = state;
   }
 
-  public GetAuthorizationUrlParams authorizationRedirectUri(String authorizationRedirectUri) {
-    this.authorizationRedirectUri = authorizationRedirectUri;
+  public GetAuthorizationUrlParams redirectUri(String redirectUri) {
+    this.redirectUri = redirectUri;
     return this;
   }
 
    /**
-   * Get authorizationRedirectUri
-   * @return authorizationRedirectUri
+   * Get redirectUri
+   * @return redirectUri
   **/
   @ApiModelProperty(example = "https://client.example.org/cb", value = "")
-  public String getAuthorizationRedirectUri() {
-    return authorizationRedirectUri;
+  public String getRedirectUri() {
+    return redirectUri;
   }
 
-  public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
-    this.authorizationRedirectUri = authorizationRedirectUri;
+  public void setRedirectUri(String redirectUri) {
+    this.redirectUri = redirectUri;
   }
 
   public GetAuthorizationUrlParams customParameters(GetauthorizationurlCustomParameters customParameters) {
@@ -231,14 +231,14 @@ public class GetAuthorizationUrlParams {
         Objects.equals(this.acrValues, getAuthorizationUrlParams.acrValues) &&
         Objects.equals(this.prompt, getAuthorizationUrlParams.prompt) &&
         Objects.equals(this.state, getAuthorizationUrlParams.state) &&
-        Objects.equals(this.authorizationRedirectUri, getAuthorizationUrlParams.authorizationRedirectUri) &&
+        Objects.equals(this.redirectUri, getAuthorizationUrlParams.redirectUri) &&
         Objects.equals(this.customParameters, getAuthorizationUrlParams.customParameters) &&
         Objects.equals(this.params, getAuthorizationUrlParams.params);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(oxdId, scope, acrValues, prompt, state, authorizationRedirectUri, customParameters, params);
+    return Objects.hash(oxdId, scope, acrValues, prompt, state, redirectUri, customParameters, params);
   }
 
 
@@ -252,7 +252,7 @@ public class GetAuthorizationUrlParams {
     sb.append("    acrValues: ").append(toIndentedString(acrValues)).append("\n");
     sb.append("    prompt: ").append(toIndentedString(prompt)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
-    sb.append("    authorizationRedirectUri: ").append(toIndentedString(authorizationRedirectUri)).append("\n");
+    sb.append("    redirectUri: ").append(toIndentedString(redirectUri)).append("\n");
     sb.append("    customParameters: ").append(toIndentedString(customParameters)).append("\n");
     sb.append("    params: ").append(toIndentedString(params)).append("\n");
     sb.append("}");

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteParams.java
@@ -30,10 +30,10 @@ import java.util.List;
 /**
  * RegisterSiteParams
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-07-06T05:18:25.296Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-07-11T13:31:30.809Z")
 public class RegisterSiteParams {
-  @SerializedName("authorization_redirect_uri")
-  private String authorizationRedirectUri = null;
+  @SerializedName("redirect_uris")
+  private List<String> redirectUris = new ArrayList<String>();
 
   @SerializedName("op_host")
   private String opHost = null;
@@ -79,9 +79,6 @@ public class RegisterSiteParams {
 
   @SerializedName("contacts")
   private List<String> contacts = null;
-
-  @SerializedName("redirect_uris")
-  private List<String> redirectUris = null;
 
   @SerializedName("ui_locales")
   private List<String> uiLocales = null;
@@ -191,22 +188,27 @@ public class RegisterSiteParams {
   @SerializedName("custom_attributes")
   private RegistersiteCustomAttributes customAttributes = null;
 
-  public RegisterSiteParams authorizationRedirectUri(String authorizationRedirectUri) {
-    this.authorizationRedirectUri = authorizationRedirectUri;
+  public RegisterSiteParams redirectUris(List<String> redirectUris) {
+    this.redirectUris = redirectUris;
     return this;
   }
 
-  /**
-   * The only required parameter is the authorization_redirect_uri. This provide the URL where the user will be redirected after successful authorization at the OpenID Connect Provider (OP).
-   * @return authorizationRedirectUri
-   **/
-  @ApiModelProperty(example = "https://client.example.org/cb", required = true, value = "The only required parameter is the authorization_redirect_uri. This provide the URL where the user will be redirected after successful authorization at the OpenID Connect Provider (OP).")
-  public String getAuthorizationRedirectUri() {
-    return authorizationRedirectUri;
+  public RegisterSiteParams addRedirectUrisItem(String redirectUrisItem) {
+    this.redirectUris.add(redirectUrisItem);
+    return this;
   }
 
-  public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
-    this.authorizationRedirectUri = authorizationRedirectUri;
+   /**
+   * Provide the list of redirection URIs.
+   * @return redirectUris
+  **/
+  @ApiModelProperty(example = "[\"https://client.example.org/cb\"]", required = true, value = "Provide the list of redirection URIs.")
+  public List<String> getRedirectUris() {
+    return redirectUris;
+  }
+
+  public void setRedirectUris(List<String> redirectUris) {
+    this.redirectUris = redirectUris;
   }
 
   public RegisterSiteParams opHost(String opHost) {
@@ -214,10 +216,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide the URL of OpenID Provider (OP). If missing, must be present in defaults.
    * @return opHost
-   **/
+  **/
   @ApiModelProperty(example = "https://<ophostname>", value = "Provide the URL of OpenID Provider (OP). If missing, must be present in defaults.")
   public String getOpHost() {
     return opHost;
@@ -240,10 +242,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide the URLs supplied by the RP to request that the user be redirected to this location after a logout has been performed.
    * @return postLogoutRedirectUris
-   **/
+  **/
   @ApiModelProperty(example = "[\"https://client.example.org/logout/page1\",\"https://client.example.org/logout/page2\",\"https://client.example.org/logout/page3\"]", value = "Provide the URLs supplied by the RP to request that the user be redirected to this location after a logout has been performed.")
   public List<String> getPostLogoutRedirectUris() {
     return postLogoutRedirectUris;
@@ -258,10 +260,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get applicationType
    * @return applicationType
-   **/
+  **/
   @ApiModelProperty(example = "web", value = "")
   public String getApplicationType() {
     return applicationType;
@@ -284,10 +286,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide a list of the OAuth 2.0 response_type values that the Client is declaring that it will restrict itself to using. If omitted, the default is that the Client will use only the code response type.
    * @return responseTypes
-   **/
+  **/
   @ApiModelProperty(example = "[\"code\"]", value = "Provide a list of the OAuth 2.0 response_type values that the Client is declaring that it will restrict itself to using. If omitted, the default is that the Client will use only the code response type.")
   public List<String> getResponseTypes() {
     return responseTypes;
@@ -310,10 +312,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide a list of the OAuth 2.0 grant types that the Client is declaring that it will restrict itself to using.
    * @return grantTypes
-   **/
+  **/
   @ApiModelProperty(example = "[\"authorization_code\",\"client_credentials\"]", value = "Provide a list of the OAuth 2.0 grant types that the Client is declaring that it will restrict itself to using.")
   public List<String> getGrantTypes() {
     return grantTypes;
@@ -336,10 +338,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide list of scope which are used during authentication to authorize access to resource.
    * @return scope
-   **/
+  **/
   @ApiModelProperty(example = "[\"openid\"]", value = "Provide list of scope which are used during authentication to authorize access to resource.")
   public List<String> getScope() {
     return scope;
@@ -362,10 +364,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide Returns the Default requested Authentication Context Class Reference values.
    * @return acrValues
-   **/
+  **/
   @ApiModelProperty(example = "[\"basic\"]", value = "Provide Returns the Default requested Authentication Context Class Reference values.")
   public List<String> getAcrValues() {
     return acrValues;
@@ -380,10 +382,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * oxd will generate its own non-human readable name by default if client_name is not specified
    * @return clientName
-   **/
+  **/
   @ApiModelProperty(value = "oxd will generate its own non-human readable name by default if client_name is not specified")
   public String getClientName() {
     return clientName;
@@ -398,10 +400,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide the URL for the Client&#39;s JSON Web Key Set (JWK) document containing key(s) that are used for signing requests to the OP. The JWK Set may also contain the Client&#39;s encryption keys(s) that are used by the OP to encrypt the responses to the Client. When both signing and encryption keys are made available, a use (Key Use) parameter value is required for all keys in the document to indicate each key&#39;s intended usage .
    * @return clientJwksUri
-   **/
+  **/
   @ApiModelProperty(value = "Provide the URL for the Client's JSON Web Key Set (JWK) document containing key(s) that are used for signing requests to the OP. The JWK Set may also contain the Client's encryption keys(s) that are used by the OP to encrypt the responses to the Client. When both signing and encryption keys are made available, a use (Key Use) parameter value is required for all keys in the document to indicate each key's intended usage .")
   public String getClientJwksUri() {
     return clientJwksUri;
@@ -416,10 +418,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide the requested authentication method for the Token Endpoint. Valid values are none, client_secret_basic, client_secret_post, client_secret_jwt, private_key_jwt, access_token, tls_client_auth, self_signed_tls_client_auth.
    * @return clientTokenEndpointAuthMethod
-   **/
+  **/
   @ApiModelProperty(value = "Provide the requested authentication method for the Token Endpoint. Valid values are none, client_secret_basic, client_secret_post, client_secret_jwt, private_key_jwt, access_token, tls_client_auth, self_signed_tls_client_auth.")
   public String getClientTokenEndpointAuthMethod() {
     return clientTokenEndpointAuthMethod;
@@ -434,10 +436,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide the Requested Client Authentication method for the Token Endpoint. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512.
    * @return clientTokenEndpointAuthSigningAlg
-   **/
+  **/
   @ApiModelProperty(value = "Provide the Requested Client Authentication method for the Token Endpoint. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512.")
   public String getClientTokenEndpointAuthSigningAlg() {
     return clientTokenEndpointAuthSigningAlg;
@@ -460,10 +462,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide a list of request_uri values that are pre-registered by the Client for use at the Authorization Server.
    * @return clientRequestUris
-   **/
+  **/
   @ApiModelProperty(value = "Provide a list of request_uri values that are pre-registered by the Client for use at the Authorization Server.")
   public List<String> getClientRequestUris() {
     return clientRequestUris;
@@ -486,10 +488,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide frontchannel logout uris.
    * @return clientFrontchannelLogoutUris
-   **/
+  **/
   @ApiModelProperty(value = "Provide frontchannel logout uris.")
   public List<String> getClientFrontchannelLogoutUris() {
     return clientFrontchannelLogoutUris;
@@ -504,10 +506,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide the URL using the https scheme to be used in calculating Pseudonymous Identifiers by the OP. The URL references a file with a single JSON array of redirect_uri values.
    * @return clientSectorIdentifierUri
-   **/
+  **/
   @ApiModelProperty(value = "Provide the URL using the https scheme to be used in calculating Pseudonymous Identifiers by the OP. The URL references a file with a single JSON array of redirect_uri values.")
   public String getClientSectorIdentifierUri() {
     return clientSectorIdentifierUri;
@@ -530,10 +532,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide a list of e-mail addresses for people allowed to administer the information for this Client
    * @return contacts
-   **/
+  **/
   @ApiModelProperty(example = "[\"foo_bar@spam.org\"]", value = "Provide a list of e-mail addresses for people allowed to administer the information for this Client")
   public List<String> getContacts() {
     return contacts;
@@ -541,32 +543,6 @@ public class RegisterSiteParams {
 
   public void setContacts(List<String> contacts) {
     this.contacts = contacts;
-  }
-
-  public RegisterSiteParams redirectUris(List<String> redirectUris) {
-    this.redirectUris = redirectUris;
-    return this;
-  }
-
-  public RegisterSiteParams addRedirectUrisItem(String redirectUrisItem) {
-    if (this.redirectUris == null) {
-      this.redirectUris = new ArrayList<String>();
-    }
-    this.redirectUris.add(redirectUrisItem);
-    return this;
-  }
-
-  /**
-   * Provide the list of redirection URIs.
-   * @return redirectUris
-   **/
-  @ApiModelProperty(example = "[\"https://client.example.org/cb\"]", value = "Provide the list of redirection URIs.")
-  public List<String> getRedirectUris() {
-    return redirectUris;
-  }
-
-  public void setRedirectUris(List<String> redirectUris) {
-    this.redirectUris = redirectUris;
   }
 
   public RegisterSiteParams uiLocales(List<String> uiLocales) {
@@ -582,10 +558,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide ui_locales, which can be used to pass the localization from the client application to the server application in the authorize request.
    * @return uiLocales
-   **/
+  **/
   @ApiModelProperty(value = "Provide ui_locales, which can be used to pass the localization from the client application to the server application in the authorize request.")
   public List<String> getUiLocales() {
     return uiLocales;
@@ -608,10 +584,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Provide claims_locales, which end-user&#39;s preferred languages and scripts for Claims being returned.
    * @return claimsLocales
-   **/
+  **/
   @ApiModelProperty(value = "Provide claims_locales, which end-user's preferred languages and scripts for Claims being returned.")
   public List<String> getClaimsLocales() {
     return claimsLocales;
@@ -634,10 +610,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get claimsRedirectUri
    * @return claimsRedirectUri
-   **/
+  **/
   @ApiModelProperty(value = "")
   public List<String> getClaimsRedirectUri() {
     return claimsRedirectUri;
@@ -652,10 +628,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * client id of existing client, ignores all other parameters and skips new client registration forcing to use existing client (client_secret is required if this parameter is set).
    * @return clientId
-   **/
+  **/
   @ApiModelProperty(value = "client id of existing client, ignores all other parameters and skips new client registration forcing to use existing client (client_secret is required if this parameter is set).")
   public String getClientId() {
     return clientId;
@@ -670,10 +646,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * client secret of existing client, must be used together with client_id
    * @return clientSecret
-   **/
+  **/
   @ApiModelProperty(value = "client secret of existing client, must be used together with client_id")
   public String getClientSecret() {
     return clientSecret;
@@ -688,10 +664,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies whether client is trusted. Default value is false.
    * @return trustedClient
-   **/
+  **/
   @ApiModelProperty(value = "specifies whether client is trusted. Default value is false.")
   public Boolean isTrustedClient() {
     return trustedClient;
@@ -706,10 +682,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies whether access_token should be return as JWT or not. Default value is false.
    * @return accessTokenAsJwt
-   **/
+  **/
   @ApiModelProperty(value = "specifies whether access_token should be return as JWT or not. Default value is false.")
   public Boolean isAccessTokenAsJwt() {
     return accessTokenAsJwt;
@@ -724,10 +700,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * sets signing algorithm used for JWT signing. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512
    * @return accessTokenSigningAlg
-   **/
+  **/
   @ApiModelProperty(value = "sets signing algorithm used for JWT signing. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512")
   public String getAccessTokenSigningAlg() {
     return accessTokenSigningAlg;
@@ -742,10 +718,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies whether RPT should be return as JWT or not. Default value is false.
    * @return rptAsJwt
-   **/
+  **/
   @ApiModelProperty(value = "specifies whether RPT should be return as JWT or not. Default value is false.")
   public Boolean isRptAsJwt() {
     return rptAsJwt;
@@ -760,10 +736,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies an URL that references a logo for the Client application.
    * @return logoUri
-   **/
+  **/
   @ApiModelProperty(example = "https://client.example.org/logo.png", value = "specifies an URL that references a logo for the Client application.")
   public String getLogoUri() {
     return logoUri;
@@ -778,10 +754,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies an URL of the home page of the Client.
    * @return clientUri
-   **/
+  **/
   @ApiModelProperty(example = "https://client.example.org/page", value = "specifies an URL of the home page of the Client.")
   public String getClientUri() {
     return clientUri;
@@ -796,10 +772,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies an URL that the Relying Party Client provides to the End-User to read about the how the profile data will be used.
    * @return policyUri
-   **/
+  **/
   @ApiModelProperty(example = "https://client.example.org/page", value = "specifies an URL that the Relying Party Client provides to the End-User to read about the how the profile data will be used.")
   public String getPolicyUri() {
     return policyUri;
@@ -814,10 +790,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies if front channel logout session required.
    * @return frontChannelLogoutSessionRequired
-   **/
+  **/
   @ApiModelProperty(example = "true", value = "specifies if front channel logout session required.")
   public Boolean isFrontChannelLogoutSessionRequired() {
     return frontChannelLogoutSessionRequired;
@@ -832,10 +808,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies an URL that the Relying Party Client provides to the End-User to read about the Relying Party&#39;s terms.
    * @return tosUri
-   **/
+  **/
   @ApiModelProperty(example = "https://client.example.org/page", value = "specifies an URL that the Relying Party Client provides to the End-User to read about the Relying Party's terms.")
   public String getTosUri() {
     return tosUri;
@@ -850,10 +826,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Client&#39;s JSON Web Key Set (JWK) document, passed by value. The semantics of the jwks parameter are the same as the jwks_uri parameter, other than that the JWK Set is passed by value, rather than by reference. This parameter is intended only to be used by Clients that, for some reason, are unable to use the jwks_uri parameter, for instance, by native applications that might not have a location to host the contents of the JWK Set. If a Client can use jwks_uri, it must not use jwks. One significant downside of jwks is that it does not enable key rotation. The jwks_uri and jwks parameters must not be used together.
    * @return jwks
-   **/
+  **/
   @ApiModelProperty(example = "{\"key1\": \"value1\", \"key2\": \"value2\"}", value = "Client's JSON Web Key Set (JWK) document, passed by value. The semantics of the jwks parameter are the same as the jwks_uri parameter, other than that the JWK Set is passed by value, rather than by reference. This parameter is intended only to be used by Clients that, for some reason, are unable to use the jwks_uri parameter, for instance, by native applications that might not have a location to host the contents of the JWK Set. If a Client can use jwks_uri, it must not use jwks. One significant downside of jwks is that it does not enable key rotation. The jwks_uri and jwks parameters must not be used together.")
   public String getJwks() {
     return jwks;
@@ -868,10 +844,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get idTokenBindingCnf
    * @return idTokenBindingCnf
-   **/
+  **/
   @ApiModelProperty(example = "4NRB1-0XZABZI9E6-5SM3R", value = "")
   public String getIdTokenBindingCnf() {
     return idTokenBindingCnf;
@@ -886,10 +862,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get tlsClientAuthSubjectDn
    * @return tlsClientAuthSubjectDn
-   **/
+  **/
   @ApiModelProperty(example = "www.test.com", value = "")
   public String getTlsClientAuthSubjectDn() {
     return tlsClientAuthSubjectDn;
@@ -904,10 +880,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose to run introspection script before access_token_as_jwt creation and include claims.
    * @return runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims
-   **/
+  **/
   @ApiModelProperty(example = "true", value = "choose to run introspection script before access_token_as_jwt creation and include claims.")
   public Boolean isRunIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims() {
     return runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims;
@@ -922,10 +898,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWS alg algorithm (JWA) required for the ID Token issued to this client_id. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512
    * @return idTokenSignedResponseAlg
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWS alg algorithm (JWA) required for the ID Token issued to this client_id. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512")
   public String getIdTokenSignedResponseAlg() {
     return idTokenSignedResponseAlg;
@@ -940,10 +916,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWE alg algorithm (JWA) required for encrypting the ID Token issued to this client_id. Valid values are RSA1_5, RSA-OAEP, A128KW, A256KW
    * @return idTokenEncryptedResponseAlg
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWE alg algorithm (JWA) required for encrypting the ID Token issued to this client_id. Valid values are RSA1_5, RSA-OAEP, A128KW, A256KW")
   public String getIdTokenEncryptedResponseAlg() {
     return idTokenEncryptedResponseAlg;
@@ -958,10 +934,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWE enc algorithm (JWA) required for symmetric encryption of the ID Token issued to this client_id. Valid values are A128CBC+HS256, A256CBC+HS512, A128GCM, A256GCM
    * @return idTokenEncryptedResponseEnc
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWE enc algorithm (JWA) required for symmetric encryption of the ID Token issued to this client_id. Valid values are A128CBC+HS256, A256CBC+HS512, A128GCM, A256GCM")
   public String getIdTokenEncryptedResponseEnc() {
     return idTokenEncryptedResponseEnc;
@@ -976,10 +952,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWS alg algorithm (JWA) required for UserInfo responses. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512
    * @return userInfoSignedResponseAlg
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWS alg algorithm (JWA) required for UserInfo responses. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512")
   public String getUserInfoSignedResponseAlg() {
     return userInfoSignedResponseAlg;
@@ -994,10 +970,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWE alg algorithm (JWA) required for encrypting UserInfo responses. Valid values are RSA1_5, RSA_OAEP, A128KW, A256KW
    * @return userInfoEncryptedResponseAlg
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWE alg algorithm (JWA) required for encrypting UserInfo responses. Valid values are RSA1_5, RSA_OAEP, A128KW, A256KW")
   public String getUserInfoEncryptedResponseAlg() {
     return userInfoEncryptedResponseAlg;
@@ -1012,10 +988,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWE enc algorithm (JWA) required for symmetric encryption of UserInfo responses. Valid values are A128CBC+HS256, A256CBC+HS512, A128GCM, A256GCM
    * @return userInfoEncryptedResponseEnc
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWE enc algorithm (JWA) required for symmetric encryption of UserInfo responses. Valid values are A128CBC+HS256, A256CBC+HS512, A128GCM, A256GCM")
   public String getUserInfoEncryptedResponseEnc() {
     return userInfoEncryptedResponseEnc;
@@ -1030,10 +1006,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWS alg algorithm (JWA) that must be required by the Authorization Server. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512
    * @return requestObjectSigningAlg
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWS alg algorithm (JWA) that must be required by the Authorization Server. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512")
   public String getRequestObjectSigningAlg() {
     return requestObjectSigningAlg;
@@ -1048,10 +1024,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWE alg algorithm (JWA) the RP is declaring that it may use for encrypting Request Objects sent to the OP. Valid values are RSA1_5, RSA_OAEP, A128KW, A256KW
    * @return requestObjectEncryptionAlg
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWE alg algorithm (JWA) the RP is declaring that it may use for encrypting Request Objects sent to the OP. Valid values are RSA1_5, RSA_OAEP, A128KW, A256KW")
   public String getRequestObjectEncryptionAlg() {
     return requestObjectEncryptionAlg;
@@ -1066,10 +1042,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * choose the JWE enc algorithm (JWA) the RP is declaring that it may use for encrypting Request Objects sent to the OP. Valid values are A128CBC+HS256, A256CBC+HS512, A128GCM, A256GCM
    * @return requestObjectEncryptionEnc
-   **/
+  **/
   @ApiModelProperty(value = "choose the JWE enc algorithm (JWA) the RP is declaring that it may use for encrypting Request Objects sent to the OP. Valid values are A128CBC+HS256, A256CBC+HS512, A128GCM, A256GCM")
   public String getRequestObjectEncryptionEnc() {
     return requestObjectEncryptionEnc;
@@ -1084,10 +1060,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies the Default Maximum Authentication Age.
    * @return defaultMaxAge
-   **/
+  **/
   @ApiModelProperty(example = "1000000", value = "specifies the Default Maximum Authentication Age.")
   public Integer getDefaultMaxAge() {
     return defaultMaxAge;
@@ -1102,10 +1078,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies the Boolean value specifying whether the auth_time claim in the id_token is required. It is required when the value is true. The auth_time claim request in the request object overrides this setting.
    * @return requireAuthTime
-   **/
+  **/
   @ApiModelProperty(example = "true", value = "specifies the Boolean value specifying whether the auth_time claim in the id_token is required. It is required when the value is true. The auth_time claim request in the request object overrides this setting.")
   public Boolean isRequireAuthTime() {
     return requireAuthTime;
@@ -1120,10 +1096,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies the URI using the https scheme that the authorization server can call to initiate a login at the client.
    * @return initiateLoginUri
-   **/
+  **/
   @ApiModelProperty(example = "https://client.example.org/authorization/page", value = "specifies the URI using the https scheme that the authorization server can call to initiate a login at the client.")
   public String getInitiateLoginUri() {
     return initiateLoginUri;
@@ -1146,10 +1122,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies authorized JavaScript origins.
    * @return authorizedOrigins
-   **/
+  **/
   @ApiModelProperty(value = "specifies authorized JavaScript origins.")
   public List<String> getAuthorizedOrigins() {
     return authorizedOrigins;
@@ -1164,10 +1140,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies the Client-specific access token expiration.
    * @return accessTokenLifetime
-   **/
+  **/
   @ApiModelProperty(example = "100000000", value = "specifies the Client-specific access token expiration.")
   public Integer getAccessTokenLifetime() {
     return accessTokenLifetime;
@@ -1182,10 +1158,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies a unique identifier string (UUID) assigned by the client developer or software publisher used by registration endpoints to identify the client software to be dynamically registered.
    * @return softwareId
-   **/
+  **/
   @ApiModelProperty(example = "4NRB1-0XZABZI9E6-5SM3R", value = "specifies a unique identifier string (UUID) assigned by the client developer or software publisher used by registration endpoints to identify the client software to be dynamically registered.")
   public String getSoftwareId() {
     return softwareId;
@@ -1200,10 +1176,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies a version identifier string for the client software identified by &#39;software_id&#39;. The value of the &#39;software_version&#39; should change on any update to the client software identified by the same &#39;software_id&#39;.
    * @return softwareVersion
-   **/
+  **/
   @ApiModelProperty(example = "2.1", value = "specifies a version identifier string for the client software identified by 'software_id'. The value of the 'software_version' should change on any update to the client software identified by the same 'software_id'.")
   public String getSoftwareVersion() {
     return softwareVersion;
@@ -1218,10 +1194,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies a software statement containing client metadata values about the client software as claims. This is a string value containing the entire signed JWT.
    * @return softwareStatement
-   **/
+  **/
   @ApiModelProperty(value = "specifies a software statement containing client metadata values about the client software as claims. This is a string value containing the entire signed JWT.")
   public String getSoftwareStatement() {
     return softwareStatement;
@@ -1236,10 +1212,10 @@ public class RegisterSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get customAttributes
    * @return customAttributes
-   **/
+  **/
   @ApiModelProperty(value = "")
   public RegistersiteCustomAttributes getCustomAttributes() {
     return customAttributes;
@@ -1251,7 +1227,7 @@ public class RegisterSiteParams {
 
 
   @Override
-  public boolean equals(java.lang.Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
@@ -1259,64 +1235,63 @@ public class RegisterSiteParams {
       return false;
     }
     RegisterSiteParams registerSiteParams = (RegisterSiteParams) o;
-    return Objects.equals(this.authorizationRedirectUri, registerSiteParams.authorizationRedirectUri) &&
-            Objects.equals(this.opHost, registerSiteParams.opHost) &&
-            Objects.equals(this.postLogoutRedirectUris, registerSiteParams.postLogoutRedirectUris) &&
-            Objects.equals(this.applicationType, registerSiteParams.applicationType) &&
-            Objects.equals(this.responseTypes, registerSiteParams.responseTypes) &&
-            Objects.equals(this.grantTypes, registerSiteParams.grantTypes) &&
-            Objects.equals(this.scope, registerSiteParams.scope) &&
-            Objects.equals(this.acrValues, registerSiteParams.acrValues) &&
-            Objects.equals(this.clientName, registerSiteParams.clientName) &&
-            Objects.equals(this.clientJwksUri, registerSiteParams.clientJwksUri) &&
-            Objects.equals(this.clientTokenEndpointAuthMethod, registerSiteParams.clientTokenEndpointAuthMethod) &&
-            Objects.equals(this.clientTokenEndpointAuthSigningAlg, registerSiteParams.clientTokenEndpointAuthSigningAlg) &&
-            Objects.equals(this.clientRequestUris, registerSiteParams.clientRequestUris) &&
-            Objects.equals(this.clientFrontchannelLogoutUris, registerSiteParams.clientFrontchannelLogoutUris) &&
-            Objects.equals(this.clientSectorIdentifierUri, registerSiteParams.clientSectorIdentifierUri) &&
-            Objects.equals(this.contacts, registerSiteParams.contacts) &&
-            Objects.equals(this.redirectUris, registerSiteParams.redirectUris) &&
-            Objects.equals(this.uiLocales, registerSiteParams.uiLocales) &&
-            Objects.equals(this.claimsLocales, registerSiteParams.claimsLocales) &&
-            Objects.equals(this.claimsRedirectUri, registerSiteParams.claimsRedirectUri) &&
-            Objects.equals(this.clientId, registerSiteParams.clientId) &&
-            Objects.equals(this.clientSecret, registerSiteParams.clientSecret) &&
-            Objects.equals(this.trustedClient, registerSiteParams.trustedClient) &&
-            Objects.equals(this.accessTokenAsJwt, registerSiteParams.accessTokenAsJwt) &&
-            Objects.equals(this.accessTokenSigningAlg, registerSiteParams.accessTokenSigningAlg) &&
-            Objects.equals(this.rptAsJwt, registerSiteParams.rptAsJwt) &&
-            Objects.equals(this.logoUri, registerSiteParams.logoUri) &&
-            Objects.equals(this.clientUri, registerSiteParams.clientUri) &&
-            Objects.equals(this.policyUri, registerSiteParams.policyUri) &&
-            Objects.equals(this.frontChannelLogoutSessionRequired, registerSiteParams.frontChannelLogoutSessionRequired) &&
-            Objects.equals(this.tosUri, registerSiteParams.tosUri) &&
-            Objects.equals(this.jwks, registerSiteParams.jwks) &&
-            Objects.equals(this.idTokenBindingCnf, registerSiteParams.idTokenBindingCnf) &&
-            Objects.equals(this.tlsClientAuthSubjectDn, registerSiteParams.tlsClientAuthSubjectDn) &&
-            Objects.equals(this.runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims, registerSiteParams.runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims) &&
-            Objects.equals(this.idTokenSignedResponseAlg, registerSiteParams.idTokenSignedResponseAlg) &&
-            Objects.equals(this.idTokenEncryptedResponseAlg, registerSiteParams.idTokenEncryptedResponseAlg) &&
-            Objects.equals(this.idTokenEncryptedResponseEnc, registerSiteParams.idTokenEncryptedResponseEnc) &&
-            Objects.equals(this.userInfoSignedResponseAlg, registerSiteParams.userInfoSignedResponseAlg) &&
-            Objects.equals(this.userInfoEncryptedResponseAlg, registerSiteParams.userInfoEncryptedResponseAlg) &&
-            Objects.equals(this.userInfoEncryptedResponseEnc, registerSiteParams.userInfoEncryptedResponseEnc) &&
-            Objects.equals(this.requestObjectSigningAlg, registerSiteParams.requestObjectSigningAlg) &&
-            Objects.equals(this.requestObjectEncryptionAlg, registerSiteParams.requestObjectEncryptionAlg) &&
-            Objects.equals(this.requestObjectEncryptionEnc, registerSiteParams.requestObjectEncryptionEnc) &&
-            Objects.equals(this.defaultMaxAge, registerSiteParams.defaultMaxAge) &&
-            Objects.equals(this.requireAuthTime, registerSiteParams.requireAuthTime) &&
-            Objects.equals(this.initiateLoginUri, registerSiteParams.initiateLoginUri) &&
-            Objects.equals(this.authorizedOrigins, registerSiteParams.authorizedOrigins) &&
-            Objects.equals(this.accessTokenLifetime, registerSiteParams.accessTokenLifetime) &&
-            Objects.equals(this.softwareId, registerSiteParams.softwareId) &&
-            Objects.equals(this.softwareVersion, registerSiteParams.softwareVersion) &&
-            Objects.equals(this.softwareStatement, registerSiteParams.softwareStatement) &&
-            Objects.equals(this.customAttributes, registerSiteParams.customAttributes);
+    return Objects.equals(this.redirectUris, registerSiteParams.redirectUris) &&
+        Objects.equals(this.opHost, registerSiteParams.opHost) &&
+        Objects.equals(this.postLogoutRedirectUris, registerSiteParams.postLogoutRedirectUris) &&
+        Objects.equals(this.applicationType, registerSiteParams.applicationType) &&
+        Objects.equals(this.responseTypes, registerSiteParams.responseTypes) &&
+        Objects.equals(this.grantTypes, registerSiteParams.grantTypes) &&
+        Objects.equals(this.scope, registerSiteParams.scope) &&
+        Objects.equals(this.acrValues, registerSiteParams.acrValues) &&
+        Objects.equals(this.clientName, registerSiteParams.clientName) &&
+        Objects.equals(this.clientJwksUri, registerSiteParams.clientJwksUri) &&
+        Objects.equals(this.clientTokenEndpointAuthMethod, registerSiteParams.clientTokenEndpointAuthMethod) &&
+        Objects.equals(this.clientTokenEndpointAuthSigningAlg, registerSiteParams.clientTokenEndpointAuthSigningAlg) &&
+        Objects.equals(this.clientRequestUris, registerSiteParams.clientRequestUris) &&
+        Objects.equals(this.clientFrontchannelLogoutUris, registerSiteParams.clientFrontchannelLogoutUris) &&
+        Objects.equals(this.clientSectorIdentifierUri, registerSiteParams.clientSectorIdentifierUri) &&
+        Objects.equals(this.contacts, registerSiteParams.contacts) &&
+        Objects.equals(this.uiLocales, registerSiteParams.uiLocales) &&
+        Objects.equals(this.claimsLocales, registerSiteParams.claimsLocales) &&
+        Objects.equals(this.claimsRedirectUri, registerSiteParams.claimsRedirectUri) &&
+        Objects.equals(this.clientId, registerSiteParams.clientId) &&
+        Objects.equals(this.clientSecret, registerSiteParams.clientSecret) &&
+        Objects.equals(this.trustedClient, registerSiteParams.trustedClient) &&
+        Objects.equals(this.accessTokenAsJwt, registerSiteParams.accessTokenAsJwt) &&
+        Objects.equals(this.accessTokenSigningAlg, registerSiteParams.accessTokenSigningAlg) &&
+        Objects.equals(this.rptAsJwt, registerSiteParams.rptAsJwt) &&
+        Objects.equals(this.logoUri, registerSiteParams.logoUri) &&
+        Objects.equals(this.clientUri, registerSiteParams.clientUri) &&
+        Objects.equals(this.policyUri, registerSiteParams.policyUri) &&
+        Objects.equals(this.frontChannelLogoutSessionRequired, registerSiteParams.frontChannelLogoutSessionRequired) &&
+        Objects.equals(this.tosUri, registerSiteParams.tosUri) &&
+        Objects.equals(this.jwks, registerSiteParams.jwks) &&
+        Objects.equals(this.idTokenBindingCnf, registerSiteParams.idTokenBindingCnf) &&
+        Objects.equals(this.tlsClientAuthSubjectDn, registerSiteParams.tlsClientAuthSubjectDn) &&
+        Objects.equals(this.runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims, registerSiteParams.runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims) &&
+        Objects.equals(this.idTokenSignedResponseAlg, registerSiteParams.idTokenSignedResponseAlg) &&
+        Objects.equals(this.idTokenEncryptedResponseAlg, registerSiteParams.idTokenEncryptedResponseAlg) &&
+        Objects.equals(this.idTokenEncryptedResponseEnc, registerSiteParams.idTokenEncryptedResponseEnc) &&
+        Objects.equals(this.userInfoSignedResponseAlg, registerSiteParams.userInfoSignedResponseAlg) &&
+        Objects.equals(this.userInfoEncryptedResponseAlg, registerSiteParams.userInfoEncryptedResponseAlg) &&
+        Objects.equals(this.userInfoEncryptedResponseEnc, registerSiteParams.userInfoEncryptedResponseEnc) &&
+        Objects.equals(this.requestObjectSigningAlg, registerSiteParams.requestObjectSigningAlg) &&
+        Objects.equals(this.requestObjectEncryptionAlg, registerSiteParams.requestObjectEncryptionAlg) &&
+        Objects.equals(this.requestObjectEncryptionEnc, registerSiteParams.requestObjectEncryptionEnc) &&
+        Objects.equals(this.defaultMaxAge, registerSiteParams.defaultMaxAge) &&
+        Objects.equals(this.requireAuthTime, registerSiteParams.requireAuthTime) &&
+        Objects.equals(this.initiateLoginUri, registerSiteParams.initiateLoginUri) &&
+        Objects.equals(this.authorizedOrigins, registerSiteParams.authorizedOrigins) &&
+        Objects.equals(this.accessTokenLifetime, registerSiteParams.accessTokenLifetime) &&
+        Objects.equals(this.softwareId, registerSiteParams.softwareId) &&
+        Objects.equals(this.softwareVersion, registerSiteParams.softwareVersion) &&
+        Objects.equals(this.softwareStatement, registerSiteParams.softwareStatement) &&
+        Objects.equals(this.customAttributes, registerSiteParams.customAttributes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(authorizationRedirectUri, opHost, postLogoutRedirectUris, applicationType, responseTypes, grantTypes, scope, acrValues, clientName, clientJwksUri, clientTokenEndpointAuthMethod, clientTokenEndpointAuthSigningAlg, clientRequestUris, clientFrontchannelLogoutUris, clientSectorIdentifierUri, contacts, redirectUris, uiLocales, claimsLocales, claimsRedirectUri, clientId, clientSecret, trustedClient, accessTokenAsJwt, accessTokenSigningAlg, rptAsJwt, logoUri, clientUri, policyUri, frontChannelLogoutSessionRequired, tosUri, jwks, idTokenBindingCnf, tlsClientAuthSubjectDn, runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims, idTokenSignedResponseAlg, idTokenEncryptedResponseAlg, idTokenEncryptedResponseEnc, userInfoSignedResponseAlg, userInfoEncryptedResponseAlg, userInfoEncryptedResponseEnc, requestObjectSigningAlg, requestObjectEncryptionAlg, requestObjectEncryptionEnc, defaultMaxAge, requireAuthTime, initiateLoginUri, authorizedOrigins, accessTokenLifetime, softwareId, softwareVersion, softwareStatement, customAttributes);
+    return Objects.hash(redirectUris, opHost, postLogoutRedirectUris, applicationType, responseTypes, grantTypes, scope, acrValues, clientName, clientJwksUri, clientTokenEndpointAuthMethod, clientTokenEndpointAuthSigningAlg, clientRequestUris, clientFrontchannelLogoutUris, clientSectorIdentifierUri, contacts, uiLocales, claimsLocales, claimsRedirectUri, clientId, clientSecret, trustedClient, accessTokenAsJwt, accessTokenSigningAlg, rptAsJwt, logoUri, clientUri, policyUri, frontChannelLogoutSessionRequired, tosUri, jwks, idTokenBindingCnf, tlsClientAuthSubjectDn, runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims, idTokenSignedResponseAlg, idTokenEncryptedResponseAlg, idTokenEncryptedResponseEnc, userInfoSignedResponseAlg, userInfoEncryptedResponseAlg, userInfoEncryptedResponseEnc, requestObjectSigningAlg, requestObjectEncryptionAlg, requestObjectEncryptionEnc, defaultMaxAge, requireAuthTime, initiateLoginUri, authorizedOrigins, accessTokenLifetime, softwareId, softwareVersion, softwareStatement, customAttributes);
   }
 
 
@@ -1324,8 +1299,8 @@ public class RegisterSiteParams {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class RegisterSiteParams {\n");
-
-    sb.append("    authorizationRedirectUri: ").append(toIndentedString(authorizationRedirectUri)).append("\n");
+    
+    sb.append("    redirectUris: ").append(toIndentedString(redirectUris)).append("\n");
     sb.append("    opHost: ").append(toIndentedString(opHost)).append("\n");
     sb.append("    postLogoutRedirectUris: ").append(toIndentedString(postLogoutRedirectUris)).append("\n");
     sb.append("    applicationType: ").append(toIndentedString(applicationType)).append("\n");
@@ -1341,7 +1316,6 @@ public class RegisterSiteParams {
     sb.append("    clientFrontchannelLogoutUris: ").append(toIndentedString(clientFrontchannelLogoutUris)).append("\n");
     sb.append("    clientSectorIdentifierUri: ").append(toIndentedString(clientSectorIdentifierUri)).append("\n");
     sb.append("    contacts: ").append(toIndentedString(contacts)).append("\n");
-    sb.append("    redirectUris: ").append(toIndentedString(redirectUris)).append("\n");
     sb.append("    uiLocales: ").append(toIndentedString(uiLocales)).append("\n");
     sb.append("    claimsLocales: ").append(toIndentedString(claimsLocales)).append("\n");
     sb.append("    claimsRedirectUri: ").append(toIndentedString(claimsRedirectUri)).append("\n");
@@ -1386,7 +1360,7 @@ public class RegisterSiteParams {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(java.lang.Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteParams.java
@@ -29,13 +29,13 @@ import java.util.List;
 /**
  * UpdateSiteParams
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T12:57:28.203Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-07-11T13:31:30.809Z")
 public class UpdateSiteParams {
   @SerializedName("oxd_id")
   private String oxdId = null;
 
-  @SerializedName("authorization_redirect_uri")
-  private String authorizationRedirectUri = null;
+  @SerializedName("redirect_uris")
+  private List<String> redirectUris = null;
 
   @SerializedName("post_logout_redirect_uris")
   private List<String> postLogoutRedirectUris = null;
@@ -87,10 +87,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get oxdId
    * @return oxdId
-   **/
+  **/
   @ApiModelProperty(example = "6F9619FF-8B86-D011-B42D-00CF4FC964FF", required = true, value = "")
   public String getOxdId() {
     return oxdId;
@@ -100,22 +100,30 @@ public class UpdateSiteParams {
     this.oxdId = oxdId;
   }
 
-  public UpdateSiteParams authorizationRedirectUri(String authorizationRedirectUri) {
-    this.authorizationRedirectUri = authorizationRedirectUri;
+  public UpdateSiteParams redirectUris(List<String> redirectUris) {
+    this.redirectUris = redirectUris;
     return this;
   }
 
-  /**
-   * Get authorizationRedirectUri
-   * @return authorizationRedirectUri
-   **/
-  @ApiModelProperty(example = "https://client.example.org/cb", value = "")
-  public String getAuthorizationRedirectUri() {
-    return authorizationRedirectUri;
+  public UpdateSiteParams addRedirectUrisItem(String redirectUrisItem) {
+    if (this.redirectUris == null) {
+      this.redirectUris = new ArrayList<String>();
+    }
+    this.redirectUris.add(redirectUrisItem);
+    return this;
   }
 
-  public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
-    this.authorizationRedirectUri = authorizationRedirectUri;
+   /**
+   * Provide the list of redirection URIs.
+   * @return redirectUris
+  **/
+  @ApiModelProperty(example = "[\"https://client.example.org/cb\"]", value = "Provide the list of redirection URIs.")
+  public List<String> getRedirectUris() {
+    return redirectUris;
+  }
+
+  public void setRedirectUris(List<String> redirectUris) {
+    this.redirectUris = redirectUris;
   }
 
   public UpdateSiteParams postLogoutRedirectUris(List<String> postLogoutRedirectUris) {
@@ -131,10 +139,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get postLogoutRedirectUris
    * @return postLogoutRedirectUris
-   **/
+  **/
   @ApiModelProperty(example = "[\"https://client.example.org/logout/page1\",\"https://client.example.org/logout/page2\",\"https://client.example.org/logout/page3\"]", value = "")
   public List<String> getPostLogoutRedirectUris() {
     return postLogoutRedirectUris;
@@ -157,10 +165,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get responseTypes
    * @return responseTypes
-   **/
+  **/
   @ApiModelProperty(example = "[\"code\"]", value = "")
   public List<String> getResponseTypes() {
     return responseTypes;
@@ -183,10 +191,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get grantTypes
    * @return grantTypes
-   **/
+  **/
   @ApiModelProperty(example = "[\"authorization_code\",\"client_credentials\"]", value = "")
   public List<String> getGrantTypes() {
     return grantTypes;
@@ -209,10 +217,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get scope
    * @return scope
-   **/
+  **/
   @ApiModelProperty(example = "[\"openid\"]", value = "")
   public List<String> getScope() {
     return scope;
@@ -235,10 +243,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get acrValues
    * @return acrValues
-   **/
+  **/
   @ApiModelProperty(example = "[\"basic\"]", value = "")
   public List<String> getAcrValues() {
     return acrValues;
@@ -253,10 +261,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get clientJwksUri
    * @return clientJwksUri
-   **/
+  **/
   @ApiModelProperty(value = "")
   public String getClientJwksUri() {
     return clientJwksUri;
@@ -271,10 +279,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get clientTokenEndpointAuthMethod
    * @return clientTokenEndpointAuthMethod
-   **/
+  **/
   @ApiModelProperty(value = "")
   public String getClientTokenEndpointAuthMethod() {
     return clientTokenEndpointAuthMethod;
@@ -297,10 +305,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get clientRequestUris
    * @return clientRequestUris
-   **/
+  **/
   @ApiModelProperty(value = "")
   public List<String> getClientRequestUris() {
     return clientRequestUris;
@@ -315,10 +323,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get clientSectorIdentifierUri
    * @return clientSectorIdentifierUri
-   **/
+  **/
   @ApiModelProperty(value = "")
   public String getClientSectorIdentifierUri() {
     return clientSectorIdentifierUri;
@@ -341,10 +349,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get contacts
    * @return contacts
-   **/
+  **/
   @ApiModelProperty(example = "[\"foo_bar@spam.org\"]", value = "")
   public List<String> getContacts() {
     return contacts;
@@ -367,10 +375,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get uiLocales
    * @return uiLocales
-   **/
+  **/
   @ApiModelProperty(value = "")
   public List<String> getUiLocales() {
     return uiLocales;
@@ -393,10 +401,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * Get claimsLocales
    * @return claimsLocales
-   **/
+  **/
   @ApiModelProperty(value = "")
   public List<String> getClaimsLocales() {
     return claimsLocales;
@@ -411,10 +419,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies whether access_token should be return as JWT or not. Default value is false.
    * @return accessTokenAsJwt
-   **/
+  **/
   @ApiModelProperty(value = "specifies whether access_token should be return as JWT or not. Default value is false.")
   public Boolean isAccessTokenAsJwt() {
     return accessTokenAsJwt;
@@ -429,10 +437,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * sets signing algorithm used for JWT signing. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512
    * @return accessTokenSigningAlg
-   **/
+  **/
   @ApiModelProperty(value = "sets signing algorithm used for JWT signing. Valid values are none, HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512")
   public String getAccessTokenSigningAlg() {
     return accessTokenSigningAlg;
@@ -447,10 +455,10 @@ public class UpdateSiteParams {
     return this;
   }
 
-  /**
+   /**
    * specifies whether RPT should be return as JWT or not. Default value is false.
    * @return rptAsJwt
-   **/
+  **/
   @ApiModelProperty(value = "specifies whether RPT should be return as JWT or not. Default value is false.")
   public Boolean isRptAsJwt() {
     return rptAsJwt;
@@ -462,7 +470,7 @@ public class UpdateSiteParams {
 
 
   @Override
-  public boolean equals(java.lang.Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
@@ -471,27 +479,27 @@ public class UpdateSiteParams {
     }
     UpdateSiteParams updateSiteParams = (UpdateSiteParams) o;
     return Objects.equals(this.oxdId, updateSiteParams.oxdId) &&
-            Objects.equals(this.authorizationRedirectUri, updateSiteParams.authorizationRedirectUri) &&
-            Objects.equals(this.postLogoutRedirectUris, updateSiteParams.postLogoutRedirectUris) &&
-            Objects.equals(this.responseTypes, updateSiteParams.responseTypes) &&
-            Objects.equals(this.grantTypes, updateSiteParams.grantTypes) &&
-            Objects.equals(this.scope, updateSiteParams.scope) &&
-            Objects.equals(this.acrValues, updateSiteParams.acrValues) &&
-            Objects.equals(this.clientJwksUri, updateSiteParams.clientJwksUri) &&
-            Objects.equals(this.clientTokenEndpointAuthMethod, updateSiteParams.clientTokenEndpointAuthMethod) &&
-            Objects.equals(this.clientRequestUris, updateSiteParams.clientRequestUris) &&
-            Objects.equals(this.clientSectorIdentifierUri, updateSiteParams.clientSectorIdentifierUri) &&
-            Objects.equals(this.contacts, updateSiteParams.contacts) &&
-            Objects.equals(this.uiLocales, updateSiteParams.uiLocales) &&
-            Objects.equals(this.claimsLocales, updateSiteParams.claimsLocales) &&
-            Objects.equals(this.accessTokenAsJwt, updateSiteParams.accessTokenAsJwt) &&
-            Objects.equals(this.accessTokenSigningAlg, updateSiteParams.accessTokenSigningAlg) &&
-            Objects.equals(this.rptAsJwt, updateSiteParams.rptAsJwt);
+        Objects.equals(this.redirectUris, updateSiteParams.redirectUris) &&
+        Objects.equals(this.postLogoutRedirectUris, updateSiteParams.postLogoutRedirectUris) &&
+        Objects.equals(this.responseTypes, updateSiteParams.responseTypes) &&
+        Objects.equals(this.grantTypes, updateSiteParams.grantTypes) &&
+        Objects.equals(this.scope, updateSiteParams.scope) &&
+        Objects.equals(this.acrValues, updateSiteParams.acrValues) &&
+        Objects.equals(this.clientJwksUri, updateSiteParams.clientJwksUri) &&
+        Objects.equals(this.clientTokenEndpointAuthMethod, updateSiteParams.clientTokenEndpointAuthMethod) &&
+        Objects.equals(this.clientRequestUris, updateSiteParams.clientRequestUris) &&
+        Objects.equals(this.clientSectorIdentifierUri, updateSiteParams.clientSectorIdentifierUri) &&
+        Objects.equals(this.contacts, updateSiteParams.contacts) &&
+        Objects.equals(this.uiLocales, updateSiteParams.uiLocales) &&
+        Objects.equals(this.claimsLocales, updateSiteParams.claimsLocales) &&
+        Objects.equals(this.accessTokenAsJwt, updateSiteParams.accessTokenAsJwt) &&
+        Objects.equals(this.accessTokenSigningAlg, updateSiteParams.accessTokenSigningAlg) &&
+        Objects.equals(this.rptAsJwt, updateSiteParams.rptAsJwt);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(oxdId, authorizationRedirectUri, postLogoutRedirectUris, responseTypes, grantTypes, scope, acrValues, clientJwksUri, clientTokenEndpointAuthMethod, clientRequestUris, clientSectorIdentifierUri, contacts, uiLocales, claimsLocales, accessTokenAsJwt, accessTokenSigningAlg, rptAsJwt);
+    return Objects.hash(oxdId, redirectUris, postLogoutRedirectUris, responseTypes, grantTypes, scope, acrValues, clientJwksUri, clientTokenEndpointAuthMethod, clientRequestUris, clientSectorIdentifierUri, contacts, uiLocales, claimsLocales, accessTokenAsJwt, accessTokenSigningAlg, rptAsJwt);
   }
 
 
@@ -499,9 +507,9 @@ public class UpdateSiteParams {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class UpdateSiteParams {\n");
-
+    
     sb.append("    oxdId: ").append(toIndentedString(oxdId)).append("\n");
-    sb.append("    authorizationRedirectUri: ").append(toIndentedString(authorizationRedirectUri)).append("\n");
+    sb.append("    redirectUris: ").append(toIndentedString(redirectUris)).append("\n");
     sb.append("    postLogoutRedirectUris: ").append(toIndentedString(postLogoutRedirectUris)).append("\n");
     sb.append("    responseTypes: ").append(toIndentedString(responseTypes)).append("\n");
     sb.append("    grantTypes: ").append(toIndentedString(grantTypes)).append("\n");
@@ -525,7 +533,7 @@ public class UpdateSiteParams {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(java.lang.Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/AccessTokenAsJwtTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/AccessTokenAsJwtTest.java
@@ -22,15 +22,15 @@ import static org.testng.Assert.*;
 public class AccessTokenAsJwtTest {
 
 
-    @Parameters({"opHost", "redirectUrl",  "postLogoutRedirectUrls"})
+    @Parameters({"opHost", "redirectUrls",  "postLogoutRedirectUrls"})
     @Test
-    public void testWithAccessTokenAsJwt(String opHost, String redirectUrl, String postLogoutRedirectUrls) throws Exception {
+    public void testWithAccessTokenAsJwt(String opHost, String redirectUrls, String postLogoutRedirectUrls) throws Exception {
 
         final DevelopersApi apiClient = api();
 
         final RegisterSiteParams siteParams = new io.swagger.client.model.RegisterSiteParams();
         siteParams.setOpHost(opHost);
-        siteParams.setAuthorizationRedirectUri(redirectUrl);
+        siteParams.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
         siteParams.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
         siteParams.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
         siteParams.setAccessTokenAsJwt(true);

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/GetAuthorizationUrlTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/GetAuthorizationUrlTest.java
@@ -15,12 +15,12 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 public class GetAuthorizationUrlTest {
-    @Parameters({"redirectUrl", "opHost"})
+    @Parameters({"redirectUrls", "opHost"})
     @Test
-    public void test(String redirectUrl, String opHost) throws Exception {
+    public void test(String redirectUrls, String opHost) throws Exception {
         DevelopersApi api = Tester.api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(api, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(api, opHost, redirectUrls);
         final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
         commandParams.setOxdId(site.getOxdId());
 
@@ -29,12 +29,12 @@ public class GetAuthorizationUrlTest {
         Tester.notEmpty(resp.getAuthorizationUrl());
     }
 
-    @Parameters({"redirectUrl", "opHost", "state"})
+    @Parameters({"redirectUrls", "opHost", "state"})
     @Test
-    public void testWithCustomStateParameter(String redirectUrl, String opHost, String state) throws Exception {
+    public void testWithCustomStateParameter(String redirectUrls, String opHost, String state) throws Exception {
         DevelopersApi api = Tester.api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(api, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(api, opHost, redirectUrls);
         final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
         commandParams.setOxdId(site.getOxdId());
         commandParams.setState(state);

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/GetLogoutUrlTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/GetLogoutUrlTest.java
@@ -24,12 +24,12 @@ import static org.testng.Assert.*;
 
 public class GetLogoutUrlTest {
 
-    @Parameters({"opHost", "redirectUrl", "postLogoutRedirectUrl"})
+    @Parameters({"opHost", "redirectUrls", "postLogoutRedirectUrl"})
     @Test
-    public void test(String opHost, String redirectUrl, String postLogoutRedirectUrl) throws Exception {
+    public void test(String opHost, String redirectUrls, String postLogoutRedirectUrl) throws Exception {
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl, postLogoutRedirectUrl, "","","" );
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls, postLogoutRedirectUrl, "","","" );
 
         final GetLogoutUriParams params = new GetLogoutUriParams();
         params.setOxdId(site.getOxdId());

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/GetTokensByCodeTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/GetTokensByCodeTest.java
@@ -26,13 +26,13 @@ public class GetTokensByCodeTest {
 
     private static final String AUTH_CODE_ENDPOINT = "/get-authorization-code";
 
-    @Parameters({"opHost", "redirectUrl", "userId", "userSecret"})
+    @Parameters({"opHost", "redirectUrls", "userId", "userSecret"})
     @Test
-    public void test(String opHost, String redirectUrl, String userId, String userSecret) throws Exception {
+    public void test(String opHost, String redirectUrls, String userId, String userSecret) throws Exception {
 
         DevelopersApi client = Tester.api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         GetTokensByCodeResponse tokensResponse = tokenByCode(client, site, userId, userSecret, CoreUtils.secureRandomString());
 

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/GetUserInfoTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/GetUserInfoTest.java
@@ -24,12 +24,12 @@ import static org.testng.Assert.*;
 
 public class GetUserInfoTest {
 
-    @Parameters({"opHost", "redirectUrl", "userId", "userSecret"})
+    @Parameters({"opHost", "redirectUrls", "userId", "userSecret"})
     @Test
-    public void test(String opHost, String redirectUrl, String userId, String userSecret) throws Exception {
+    public void test(String opHost, String redirectUrls, String userId, String userSecret) throws Exception {
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         final GetTokensByCodeResponse tokens = requestTokens(client, site, userId, userSecret);
 
         final GetUserInfoParams params = new GetUserInfoParams();

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
@@ -15,11 +15,11 @@ import static junit.framework.Assert.*;
  */
 public class IntrospectAccessTokenTest extends BaseTestCase {
 
-    @Parameters({"opHost", "redirectUrl"})
+    @Parameters({"opHost", "redirectUrls"})
     @Test
-    public void introspectAccessToken(String opHost, String redirectUrl) throws Exception {
+    public void introspectAccessToken(String opHost, String redirectUrls) throws Exception {
         DevelopersApi client = Tester.api();
-        RegisterSiteResponse setupResponse = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse setupResponse = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         GetClientTokenResponse tokenResponse = getGetClientTokenResponseData(opHost, client, setupResponse);
         assertNotNull(tokenResponse);
         final String accessToken = tokenResponse.getAccessToken();
@@ -46,12 +46,12 @@ public class IntrospectAccessTokenTest extends BaseTestCase {
     According to open id spec, introspect access token API, for authorized request with an invalid
     token, should not throw an error but should return the client as inactive.
      */
-    @Parameters({"opHost", "redirectUrl"})
+    @Parameters({"opHost", "redirectUrls"})
     @Test
     @ProtectionAccessTokenRequired
-    public void testWithInvalidToken(String opHost, String redirectUrl) throws Exception {
+    public void testWithInvalidToken(String opHost, String redirectUrls) throws Exception {
         DevelopersApi client = Tester.api();
-        RegisterSiteResponse setupData = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse setupData = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         GetClientTokenResponse tokenResponse = getGetClientTokenResponseData(opHost, client, setupData);
         assertNotNull(tokenResponse);
@@ -79,13 +79,13 @@ public class IntrospectAccessTokenTest extends BaseTestCase {
 //        assertFalse(apiIatResponse.getData().isActive());
     }
 
-    @Parameters({"opHost", "redirectUrl"})
+    @Parameters({"opHost", "redirectUrls"})
     @Test
     @ProtectionAccessTokenRequired
-    public void testWithInvalidAuthorization(String opHost, String redirectUrl) throws Exception {
+    public void testWithInvalidAuthorization(String opHost, String redirectUrls) throws Exception {
 
         DevelopersApi client = Tester.api();
-        RegisterSiteResponse setupResponse = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse setupResponse = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         GetClientTokenResponse tokenResponseData = getGetClientTokenResponseData(opHost, client, setupResponse);
         IntrospectAccessTokenParams introspectParams = new IntrospectAccessTokenParams();

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RegisterSiteTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RegisterSiteTest.java
@@ -26,20 +26,19 @@ public class RegisterSiteTest {
 
     private String oxdId = null;
 
-    @Parameters({"opHost", "redirectUrl", "logoutUrl", "postLogoutRedirectUrls", "clientJwksUri", "accessTokenSigningAlg"})
+    @Parameters({"opHost", "redirectUrls", "logoutUrl", "postLogoutRedirectUrls", "clientJwksUri", "accessTokenSigningAlg"})
     @Test
-    public void register(String opHost, String redirectUrl, String logoutUrl, String postLogoutRedirectUrls,  String clientJwksUri, String accessTokenSigningAlg) throws Exception {
+    public void register(String opHost, String redirectUrls, String logoutUrl, String postLogoutRedirectUrls,  String clientJwksUri, String accessTokenSigningAlg) throws Exception {
         DevelopersApi client = api();
 
-        registerSite(client, opHost, redirectUrl, logoutUrl, postLogoutRedirectUrls, clientJwksUri, accessTokenSigningAlg);
+        registerSite(client, opHost, redirectUrls, logoutUrl, postLogoutRedirectUrls, clientJwksUri, accessTokenSigningAlg);
 
         // more specific site registration
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
         params.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
         params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUrl));
-        params.setRedirectUris(Lists.newArrayList(redirectUrl));
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
         params.setAcrValues(new ArrayList<>());
         params.setScope(Lists.newArrayList("openid", "profile"));
         params.setGrantTypes(Lists.newArrayList("authorization_code"));
@@ -97,17 +96,17 @@ public class RegisterSiteTest {
         assertNotNull(resp);
     }
 
-    public static RegisterSiteResponse registerSite(DevelopersApi apiClient, String opHost, String redirectUrl) throws Exception {
-        return registerSite(apiClient, opHost, redirectUrl, redirectUrl, "", "", "");
+    public static RegisterSiteResponse registerSite(DevelopersApi apiClient, String opHost, String redirectUrls) throws Exception {
+        return registerSite(apiClient, opHost, redirectUrls, redirectUrls, "", "", "");
     }
 
-    public static RegisterSiteResponse registerSite(DevelopersApi apiClient, String opHost, String redirectUrl, String logoutUri, String postLogoutRedirectUrls, String clientJwksUri, String accessTokenSigningAlg) throws Exception {
+    public static RegisterSiteResponse registerSite(DevelopersApi apiClient, String opHost, String redirectUrls, String logoutUri, String postLogoutRedirectUrls, String clientJwksUri, String accessTokenSigningAlg) throws Exception {
 
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
         params.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
-        params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUri));
+        params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUri.split(" ")));
         params.setScope(Lists.newArrayList("openid", "uma_protection", "profile", "oxd"));
         params.setTrustedClient(true);
         params.setGrantTypes(Lists.newArrayList(
@@ -122,15 +121,15 @@ public class RegisterSiteTest {
         return resp;
     }
 
-    @Parameters({"opHost", "redirectUrl", "postLogoutRedirectUrls", "clientJwksUri"})
+    @Parameters({"opHost", "redirectUrls", "postLogoutRedirectUrls", "clientJwksUri"})
     @Test
-    public void registerWithInvalidAlgorithm(String opHost, String redirectUrl, String postLogoutRedirectUrls, String clientJwksUri) {
+    public void registerWithInvalidAlgorithm(String opHost, String redirectUrls, String postLogoutRedirectUrls, String clientJwksUri) {
 
         final DevelopersApi client = api();
 
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
         params.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
         params.setClientFrontchannelLogoutUris(Lists.newArrayList(""));
         params.setScope(Lists.newArrayList("openid", "uma_protection", "profile", "oxd"));

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RemoveSiteTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RemoveSiteTest.java
@@ -16,10 +16,10 @@ import static org.junit.Assert.*;
 public class RemoveSiteTest {
 
     @Test
-    @Parameters({"opHost", "redirectUrl"})
-    public void testRemoveSite(String opHost, String redirectUrl) throws Exception {
+    @Parameters({"opHost", "redirectUrls"})
+    public void testRemoveSite(String opHost, String redirectUrls) throws Exception {
         final DevelopersApi api = Tester.api();
-        RegisterSiteResponse response = RegisterSiteTest.registerSite(api, opHost, redirectUrl);
+        RegisterSiteResponse response = RegisterSiteTest.registerSite(api, opHost, redirectUrls);
 
         RemoveSiteParams params = new RemoveSiteParams();
         params.setOxdId(response.getOxdId());

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RpGetRptTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RpGetRptTest.java
@@ -21,13 +21,13 @@ import static org.testng.Assert.*;
 
 public class RpGetRptTest {
 
-    @Parameters({"opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"opHost", "redirectUrls", "rsProtect"})
     @Test
-    public void test(String opHost, String redirectUrl, String rsProtect) throws Exception {
+    public void test(String opHost, String redirectUrls, String rsProtect) throws Exception {
 
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         final UmaRpGetRptResponse response = requestRpt(client, site, rsProtect);
 
         assertNotNull(response);
@@ -35,13 +35,13 @@ public class RpGetRptTest {
     }
 
 
-    @Parameters({"opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"opHost", "redirectUrls", "rsProtect"})
     @Test
-    public void testWithSameRpt(String opHost, String redirectUrl, String rsProtect) throws Exception {
+    public void testWithSameRpt(String opHost, String redirectUrls, String rsProtect) throws Exception {
 
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         final UmaRpGetRptResponse firstResponse = requestRpt(client, site, rsProtect);
 
         final UmaRsCheckAccessResponse checkAccess = RsCheckAccessTest.checkAccess(client, site);

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RsCheckAccessTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RsCheckAccessTest.java
@@ -21,13 +21,13 @@ import static org.testng.Assert.*;
 
 public class RsCheckAccessTest {
 
-    @Parameters({"opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"opHost", "redirectUrls", "rsProtect"})
     @Test
-    public void test(String opHost, String redirectUrl, String rsProtect) throws Exception {
+    public void test(String opHost, String redirectUrls, String rsProtect) throws Exception {
 
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect));
 

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RsProtectTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RsProtectTest.java
@@ -27,25 +27,25 @@ import static org.testng.Assert.*;
 
 public class RsProtectTest {
 
-    @Parameters({"redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void protect(String redirectUrl, String opHost, String rsProtect) throws Exception {
+    public void protect(String redirectUrls, String opHost, String rsProtect) throws Exception {
 
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         protectResources(client, site, UmaFullTest.resourceList(rsProtect));
         RsCheckAccessTest.checkAccess(client, site);
 
     }
 
-    @Parameters({"redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void overwriteFalse(String redirectUrl, String opHost, String rsProtect) throws Exception {
+    public void overwriteFalse(String redirectUrls, String opHost, String rsProtect) throws Exception {
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         final List<RsResource> resources = UmaFullTest.resourceList(rsProtect);
         protectResources(client, site, resources);
@@ -64,12 +64,12 @@ public class RsProtectTest {
 
     }
 
-    @Parameters({"redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void overwriteTrue(String redirectUrl, String opHost, String rsProtect) throws Exception {
+    public void overwriteTrue(String redirectUrls, String opHost, String rsProtect) throws Exception {
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         final List<RsResource> resources = UmaFullTest.resourceList(rsProtect);
         protectResources(client, site, resources);
@@ -83,12 +83,12 @@ public class RsProtectTest {
         assertNotNull(response);
     }
 
-    @Parameters({"redirectUrl", "opHost", "rsProtectScopeExpression"})
+    @Parameters({"redirectUrls", "opHost", "rsProtectScopeExpression"})
     @Test
-    public void protectWithScopeExpression(String redirectUrl, String opHost, String rsProtectScopeExpression) throws Exception {
+    public void protectWithScopeExpression(String redirectUrls, String opHost, String rsProtectScopeExpression) throws Exception {
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         protectResources(client, site, UmaFullTest.resourceList(rsProtectScopeExpression));
 
@@ -96,12 +96,12 @@ public class RsProtectTest {
 
     }
 
-    @Parameters({"redirectUrl", "opHost", "rsProtectScopeExpressionSecond"})
+    @Parameters({"redirectUrls", "opHost", "rsProtectScopeExpressionSecond"})
     @Test
-    public void protectWithScopeExpressionSeconds(String redirectUrl, String opHost, String rsProtectScopeExpressionSecond) throws Exception {
+    public void protectWithScopeExpressionSeconds(String redirectUrls, String opHost, String rsProtectScopeExpressionSecond) throws Exception {
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         protectResources(client, site, UmaFullTest.resourceList(rsProtectScopeExpressionSecond));
 

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/SetUpTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/SetUpTest.java
@@ -18,15 +18,15 @@ public class SetUpTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(SetUpTest.class);
 
-    @Parameters({"host", "opHost", "redirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls"})
     @BeforeSuite
-    public static void beforeSuite(String host, String opHost, String redirectUrl) {
+    public static void beforeSuite(String host, String opHost, String redirectUrls) {
         try {
             LOG.debug("Running beforeSuite ...");
             Tester.setHost(host);
             Tester.setOpHost(opHost);
 
-            RegisterSiteResponse clientSetupInfo = RegisterSiteTest.registerSite(Tester.api(), opHost, redirectUrl);
+            RegisterSiteResponse clientSetupInfo = RegisterSiteTest.registerSite(Tester.api(), opHost, redirectUrls);
             Tester.setSetupData(clientSetupInfo);
 
             Preconditions.checkNotNull(Tester.getAuthorization());

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/UmaFullTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/UmaFullTest.java
@@ -31,13 +31,13 @@ import static org.testng.Assert.*;
 
 public class UmaFullTest {
 
-    @Parameters({"redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void test(String redirectUrl, String opHost, String rsProtect) throws Exception {
+    public void test(String redirectUrls, String opHost, String rsProtect) throws Exception {
 
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect));
 
@@ -55,13 +55,13 @@ public class UmaFullTest {
         assertTrue(isNotBlank(response.getPct()));
     }
 
-    @Parameters({"redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void testWithInvalidTicket(String redirectUrl, String opHost, String rsProtect) throws Exception {
+    public void testWithInvalidTicket(String redirectUrls, String opHost, String rsProtect) throws Exception {
 
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect));
 
@@ -78,13 +78,13 @@ public class UmaFullTest {
     }
 
 
-    @Parameters({"redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void testWithClaimTokenButNoTokenFormat(String redirectUrl, String opHost, String rsProtect) throws Exception {
+    public void testWithClaimTokenButNoTokenFormat(String redirectUrls, String opHost, String rsProtect) throws Exception {
 
         final DevelopersApi client = api();
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect));
 

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/UmaGetClaimsGatheringUrlTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/UmaGetClaimsGatheringUrlTest.java
@@ -22,12 +22,12 @@ import static org.testng.Assert.assertTrue;
  */
 public class UmaGetClaimsGatheringUrlTest {
 
-    @Parameters({"opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"opHost", "redirectUrls", "rsProtect", "paramRedirectUrl"})
     @Test
-    public void test(String opHost, String redirectUrl, String rsProtect) throws Exception {
+    public void test(String opHost, String redirectUrls, String rsProtect, String paramRedirectUrl) throws Exception {
 
         final DevelopersApi client = Tester.api();
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect));
 
@@ -36,7 +36,7 @@ public class UmaGetClaimsGatheringUrlTest {
         final UmaRpGetClaimsGatheringUrlParams params = new UmaRpGetClaimsGatheringUrlParams();
         params.setOxdId(site.getOxdId());
         params.setTicket(checkAccess.getTicket());
-        params.setClaimsRedirectUri(redirectUrl);
+        params.setClaimsRedirectUri(paramRedirectUrl);
 
         final UmaRpGetClaimsGatheringUrlResponse response = client.umaRpGetClaimsGatheringUrl(Tester.getAuthorization(), params);
 
@@ -46,15 +46,15 @@ public class UmaGetClaimsGatheringUrlTest {
         assertTrue(isNotBlank(parameters.get("ticket")));
         assertTrue(isNotBlank(parameters.get("state")));
         assertTrue(isNotBlank(response.getState()));
-        assertEquals(redirectUrl, parameters.get("claims_redirect_uri"));
+        assertEquals(paramRedirectUrl, parameters.get("claims_redirect_uri"));
     }
 
-    @Parameters({"opHost", "redirectUrl", "rsProtect", "state"})
+    @Parameters({"opHost", "redirectUrls", "rsProtect", "state", "paramRedirectUrl"})
     @Test
-    public void testWithCustomStateParameter(String opHost, String redirectUrl, String rsProtect, String state) throws Exception {
+    public void testWithCustomStateParameter(String opHost, String redirectUrls, String rsProtect, String state, String paramRedirectUrl) throws Exception {
 
         final DevelopersApi client = Tester.api();
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect));
 
@@ -63,7 +63,7 @@ public class UmaGetClaimsGatheringUrlTest {
         final UmaRpGetClaimsGatheringUrlParams params = new UmaRpGetClaimsGatheringUrlParams();
         params.setOxdId(site.getOxdId());
         params.setTicket(checkAccess.getTicket());
-        params.setClaimsRedirectUri(redirectUrl);
+        params.setClaimsRedirectUri(paramRedirectUrl);
         params.setState(state);
 
         final UmaRpGetClaimsGatheringUrlResponse response = client.umaRpGetClaimsGatheringUrl(Tester.getAuthorization(), params);
@@ -75,6 +75,6 @@ public class UmaGetClaimsGatheringUrlTest {
         assertTrue(isNotBlank(parameters.get("state")));
         assertTrue(isNotBlank(response.getState()));
         assertEquals(response.getState(), state);
-        assertEquals(redirectUrl, parameters.get("claims_redirect_uri"));
+        assertEquals(paramRedirectUrl, parameters.get("claims_redirect_uri"));
     }
 }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/GetAuthorizationCodeOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/GetAuthorizationCodeOperation.java
@@ -46,7 +46,7 @@ public class GetAuthorizationCodeOperation extends BaseOperation<GetAuthorizatio
         String state = Strings.isNullOrEmpty(params.getState()) ? UUID.randomUUID().toString() : params.getState();
 
         final AuthorizationRequest request = new AuthorizationRequest(responseTypes(site.getResponseTypes()),
-                site.getClientId(), site.getScope(), site.getAuthorizationRedirectUri(), nonce);
+                site.getClientId(), site.getScope(), site.getRedirectUri(), nonce);
         request.setState(state);
         request.setAuthUsername(params.getUsername());
         request.setAuthPassword(params.getPassword());

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/GetAuthorizationUrlOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/GetAuthorizationUrlOperation.java
@@ -51,12 +51,16 @@ public class GetAuthorizationUrlOperation extends BaseOperation<GetAuthorization
             scope.addAll(site.getScope());
         }
 
-        if (StringUtils.isNotBlank(params.getAuthorizationRedirectUri()) && !site.getRedirectUris().contains(params.getAuthorizationRedirectUri())) {
+        if (StringUtils.isNotBlank(params.getRedirectUri()) && !Utils.isValidUrl(params.getRedirectUri())) {
+            throw new HttpException(ErrorResponseCode.INVALID_REDIRECT_URI);
+        }
+
+        if (StringUtils.isNotBlank(params.getRedirectUri()) && !site.getRedirectUris().contains(params.getRedirectUri())) {
             throw new HttpException(ErrorResponseCode.REDIRECT_URI_IS_NOT_REGISTERED);
         }
 
         String state = StringUtils.isNotBlank(params.getState()) ? getStateService().putState(Utils.encode(params.getState())) : getStateService().generateState();
-        String redirectUri = StringUtils.isNotBlank(params.getAuthorizationRedirectUri()) ? params.getAuthorizationRedirectUri() : site.getAuthorizationRedirectUri();
+        String redirectUri = StringUtils.isNotBlank(params.getRedirectUri()) ? params.getRedirectUri() : site.getRedirectUri();
 
         authorizationEndpoint += "?response_type=" + Utils.joinAndUrlEncode(site.getResponseTypes());
         authorizationEndpoint += "&client_id=" + site.getClientId();

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/GetTokensByCodeOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/GetTokensByCodeOperation.java
@@ -44,7 +44,7 @@ public class GetTokensByCodeOperation extends BaseOperation<GetTokensByCodeParam
 
         final TokenRequest tokenRequest = new TokenRequest(GrantType.AUTHORIZATION_CODE);
         tokenRequest.setCode(params.getCode());
-        tokenRequest.setRedirectUri(site.getAuthorizationRedirectUri());
+        tokenRequest.setRedirectUri(site.getRedirectUri());
         tokenRequest.setAuthUsername(site.getClientId());
         tokenRequest.setAuthPassword(site.getClientSecret());
         tokenRequest.setAuthenticationMethod(AuthenticationMethod.CLIENT_SECRET_BASIC);

--- a/oxd-server/src/main/java/org/gluu/oxd/server/service/Rp.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/service/Rp.java
@@ -32,8 +32,8 @@ public class Rp implements Serializable {
     @JsonProperty(value = "access_token")
     private String accessToken;
 
-    @JsonProperty(value = "authorization_redirect_uri")
-    private String authorizationRedirectUri;
+    @JsonProperty(value = "redirect_uri")
+    private String redirectUri;
     @JsonProperty(value = "logout_redirect_uri")
     private String postLogoutRedirectUri;
     @JsonProperty(value = "logout_redirect_uris")
@@ -135,7 +135,7 @@ public class Rp implements Serializable {
         this.idToken = conf.idToken;
         this.accessToken = conf.accessToken;
 
-        this.authorizationRedirectUri = conf.authorizationRedirectUri;
+        this.redirectUri = conf.redirectUri;
         this.postLogoutRedirectUri = conf.postLogoutRedirectUri;
         this.postLogoutRedirectUris = conf.postLogoutRedirectUris;
         this.applicationType = conf.applicationType;
@@ -382,12 +382,12 @@ public class Rp implements Serializable {
         this.applicationType = applicationType;
     }
 
-    public String getAuthorizationRedirectUri() {
-        return authorizationRedirectUri;
+    public String getRedirectUri() {
+        return redirectUri;
     }
 
-    public void setAuthorizationRedirectUri(String authorizationRedirectUri) {
-        this.authorizationRedirectUri = authorizationRedirectUri;
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
     }
 
     public List<String> getContacts() {
@@ -627,7 +627,7 @@ public class Rp implements Serializable {
                 ", opDiscoveryPath='" + opDiscoveryPath + '\'' +
                 ", idToken='" + idToken + '\'' +
                 ", accessToken='" + accessToken + '\'' +
-                ", authorizationRedirectUri='" + authorizationRedirectUri + '\'' +
+                ", redirectUri='" + redirectUri + '\'' +
                 ", postLogoutRedirectUri='" + postLogoutRedirectUri + '\'' +
                 ", postLogoutRedirectUris='" + postLogoutRedirectUris + '\'' +
                 ", applicationType='" + applicationType + '\'' +

--- a/oxd-server/src/main/java/org/gluu/oxd/server/service/UmaTokenService.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/service/UmaTokenService.java
@@ -231,7 +231,7 @@ public class UmaTokenService {
 
         final String state = stateService.generateState();
 
-        final AuthorizationRequest request = new AuthorizationRequest(responseTypes, site.getClientId(), scopes(scopeType), site.getAuthorizationRedirectUri(), null);
+        final AuthorizationRequest request = new AuthorizationRequest(responseTypes, site.getClientId(), scopes(scopeType), site.getRedirectUri(), null);
         request.setState(state);
         request.setAuthUsername(site.getUserId());
         request.setAuthPassword(site.getUserSecret());
@@ -255,7 +255,7 @@ public class UmaTokenService {
             // 2. Request access token using the authorization code.
             final TokenRequest tokenRequest = new TokenRequest(GrantType.AUTHORIZATION_CODE);
             tokenRequest.setCode(authorizationCode);
-            tokenRequest.setRedirectUri(site.getAuthorizationRedirectUri());
+            tokenRequest.setRedirectUri(site.getRedirectUri());
             tokenRequest.setAuthUsername(site.getClientId());
             tokenRequest.setAuthPassword(site.getClientSecret());
             tokenRequest.setAuthenticationMethod(AuthenticationMethod.CLIENT_SECRET_BASIC);

--- a/oxd-server/src/main/resources/swagger.yaml
+++ b/oxd-server/src/main/resources/swagger.yaml
@@ -53,12 +53,14 @@ paths:
           schema:
             type: object
             required:
-              - authorization_redirect_uri
+              - redirect_uris
             properties:
-              authorization_redirect_uri:
-                type: string
-                example: https://client.example.org/cb
-                description: The only required parameter is the authorization_redirect_uri. This provide the URL where the user will be redirected after successful authorization at the OpenID Connect Provider (OP).
+              redirect_uris:
+                type: array
+                items:
+                  type: string
+                example: ["https://client.example.org/cb"]
+                description: Provide the list of redirection URIs. The first URL is where the user will be redirected after successful authorization at the OpenID Connect Provider (OP).
               op_host:
                 type: string
                 example: https://<ophostname>
@@ -127,12 +129,6 @@ paths:
                   type: string
                 example: ["foo_bar@spam.org"]
                 description: Provide a list of e-mail addresses for people allowed to administer the information for this Client
-              redirect_uris:
-                type: array
-                items:
-                  type: string
-                example: ["https://client.example.org/cb"]
-                description: Provide the list of redirection URIs.
               ui_locales:
                 type: array
                 items:
@@ -319,7 +315,6 @@ paths:
           description: Internal error occured. Please check oxd-server.log file for details (usually located in /var/log/oxd-server/oxd-server.log).
           schema:
             $ref: '#/definitions/ErrorResponse'
-
 
   /get-client-token:
     post:
@@ -545,9 +540,12 @@ paths:
               oxd_id:
                 type: string
                 example: 6F9619FF-8B86-D011-B42D-00CF4FC964FF
-              authorization_redirect_uri:
-                type: string
-                example: https://client.example.org/cb
+              redirect_uris:
+                type: array
+                items:
+                  type: string
+                example: ["https://client.example.org/cb"]
+                description: Provide the list of redirection URIs. The first URL is where the user will be redirected after successful authorization at the OpenID Connect Provider (OP).
               post_logout_redirect_uris:
                 type: array
                 items:
@@ -718,7 +716,7 @@ paths:
                 type: string
               state:
                 type: string
-              authorization_redirect_uri:
+              redirect_uri:
                 type: string
                 example: https://client.example.org/cb
               custom_parameters:

--- a/oxd-server/src/test/java/org/gluu/oxd/server/AccessTokenAsJwtTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/AccessTokenAsJwtTest.java
@@ -20,13 +20,13 @@ import static org.gluu.oxd.server.TestUtils.notEmpty;
  */
 public class AccessTokenAsJwtTest {
 
-    @Parameters({"host", "opHost", "redirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls", "postLogoutRedirectUrls"})
     @Test
-    public void getClientToken(String host, String opHost, String redirectUrl) throws InvalidJwtException {
+    public void getClientToken(String host, String opHost, String redirectUrls, String postLogoutRedirectUrls) throws InvalidJwtException {
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
-        params.setPostLogoutRedirectUris(Lists.newArrayList(redirectUrl));
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
+        params.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
         params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
         params.setAccessTokenAsJwt(true);
         params.setTrustedClient(true);

--- a/oxd-server/src/test/java/org/gluu/oxd/server/AuthorizationCodeFlowTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/AuthorizationCodeFlowTest.java
@@ -19,19 +19,19 @@ import static org.testng.AssertJUnit.assertNotNull;
 
 public class AuthorizationCodeFlowTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "clientId", "clientSecret", "userId", "userSecret"})
+    @Parameters({"host", "opHost", "redirectUrls", "clientId", "clientSecret", "userId", "userSecret"})
     @Test(enabled = false)
-    public void test(String host, String opHost, String redirectUrl, String clientId, String clientSecret, String userId, String userSecret) {
+    public void test(String host, String opHost, String redirectUrls, String clientId, String clientSecret, String userId, String userSecret) {
 
         ClientInterface client = org.gluu.oxd.server.Tester.newClient(host);
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         final AuthorizationCodeFlowParams params = new AuthorizationCodeFlowParams();
         params.setOxdId(site.getOxdId());
         params.setClientId(clientId);
         params.setClientSecret(clientSecret);
         params.setNonce(UUID.randomUUID().toString());
-        params.setRedirectUrl(redirectUrl);
+        params.setRedirectUrl(redirectUrls.split(" ")[0]);
         params.setScope("openid");
         params.setUserId(userId);
         params.setUserSecret(userSecret);

--- a/oxd-server/src/test/java/org/gluu/oxd/server/Base.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/Base.java
@@ -9,10 +9,10 @@ import org.testng.annotations.Parameters;
  */
 public class Base {
 
-    @Parameters({"host", "opHost", "redirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls"})
     @BeforeClass
-    public static void beforeClass(String host, String opHost, String redirectUrl) {
-        SetUpTest.beforeSuite(host, opHost, redirectUrl);
+    public static void beforeClass(String host, String opHost, String redirectUrls) {
+        SetUpTest.beforeSuite(host, opHost, redirectUrls);
     }
 
     @AfterClass

--- a/oxd-server/src/test/java/org/gluu/oxd/server/CheckAccessTokenTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/CheckAccessTokenTest.java
@@ -18,13 +18,13 @@ import static org.testng.AssertJUnit.assertTrue;
  */
 
 public class CheckAccessTokenTest {
-    @Parameters({"host", "redirectUrl", "userId", "userSecret", "opHost"})
+    @Parameters({"host", "redirectUrls", "userId", "userSecret", "opHost"})
     @Test
-    public void test(String host, String redirectUrl, String userId, String userSecret, String opHost) {
+    public void test(String host, String redirectUrls, String userId, String userSecret, String opHost) {
 
         ClientInterface client = Tester.newClient(host);
         String nonce = CoreUtils.secureRandomString();
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         GetTokensByCodeResponse2 response = GetTokensByCodeTest.tokenByCode(client, site, userId, userSecret, nonce);
 
         final CheckAccessTokenParams params = new CheckAccessTokenParams();

--- a/oxd-server/src/test/java/org/gluu/oxd/server/CheckIdTokenTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/CheckIdTokenTest.java
@@ -22,12 +22,12 @@ import static junit.framework.Assert.assertTrue;
 
 public class CheckIdTokenTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "userId", "userSecret"})
+    @Parameters({"host", "opHost", "redirectUrls", "userId", "userSecret"})
     @Test
-    public void test(String host, String opHost, String redirectUrl, String userId, String userSecret) {
+    public void test(String host, String opHost, String redirectUrls, String userId, String userSecret) {
         ClientInterface client = Tester.newClient(host);
 
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         String nonce = CoreUtils.secureRandomString();
         GetTokensByCodeResponse2 response = GetTokensByCodeTest.tokenByCode(client, site, userId, userSecret, nonce);

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetAuthorizationUrlTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetAuthorizationUrlTest.java
@@ -25,12 +25,12 @@ import static org.testng.AssertJUnit.assertTrue;
  */
 
 public class GetAuthorizationUrlTest {
-    @Parameters({"host", "redirectUrl", "opHost"})
+    @Parameters({"host", "redirectUrls", "opHost"})
     @Test
-    public void test(String host, String redirectUrl, String opHost) {
+    public void test(String host, String redirectUrls, String opHost) {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
         commandParams.setOxdId(site.getOxdId());
 
@@ -39,16 +39,16 @@ public class GetAuthorizationUrlTest {
         notEmpty(resp.getAuthorizationUrl());
     }
 
-    @Parameters({"host", "redirectUrl", "opHost", "redirectUrls", "postLogoutRedirectUrl", "logoutUrl", "paramRedirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls", "postLogoutRedirectUrl", "logoutUrl", "paramRedirectUrl"})
     @Test
-    public void testWithParameterAuthorizationUrl(String host, String redirectUrl, String opHost, String redirectUrls, String postLogoutRedirectUrl, String logoutUrl, String paramRedirectUrl) {
+    public void testWithParameterAuthorizationUrl(String host, String opHost, String redirectUrls, String postLogoutRedirectUrl, String logoutUrl, String paramRedirectUrl) {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl, postLogoutRedirectUrl, logoutUrl,
-                StringUtils.isNotBlank(redirectUrls) ? Lists.newArrayList(redirectUrls.split(" ")) : null);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls, postLogoutRedirectUrl,
+                logoutUrl);
         final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
         commandParams.setOxdId(site.getOxdId());
-        commandParams.setAuthorizationRedirectUri(paramRedirectUrl);
+        commandParams.setRedirectUri(paramRedirectUrl);
 
         final GetAuthorizationUrlResponse resp = client.getAuthorizationUrl(Tester.getAuthorization(), commandParams);
         assertNotNull(resp);
@@ -56,12 +56,12 @@ public class GetAuthorizationUrlTest {
         assertTrue(resp.getAuthorizationUrl().contains(paramRedirectUrl));
     }
 
-    @Parameters({"host", "redirectUrl", "opHost"})
+    @Parameters({"host", "redirectUrls", "opHost"})
     @Test
-    public void testWithParams(String host, String redirectUrl, String opHost) throws IOException {
+    public void testWithParams(String host, String redirectUrls, String opHost) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
         commandParams.setOxdId(site.getOxdId());
 
@@ -83,16 +83,15 @@ public class GetAuthorizationUrlTest {
     }
 
 
-    @Parameters({"host", "redirectUrl", "opHost", "redirectUrls", "postLogoutRedirectUrl", "logoutUrl", "paramRedirectUrl", "state"})
+    @Parameters({"host", "opHost", "redirectUrls", "postLogoutRedirectUrl", "logoutUrl", "paramRedirectUrl", "state"})
     @Test
-    public void testWithCustomStateParameter(String host, String redirectUrl, String opHost, String redirectUrls, String postLogoutRedirectUrl, String logoutUrl, String paramRedirectUrl, String state) throws IOException {
+    public void testWithCustomStateParameter(String host, String opHost, String redirectUrls, String postLogoutRedirectUrl, String logoutUrl, String paramRedirectUrl, String state) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl, postLogoutRedirectUrl, logoutUrl,
-                StringUtils.isNotBlank(redirectUrls) ? Lists.newArrayList(redirectUrls.split(" ")) : null);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls, postLogoutRedirectUrl, logoutUrl);
         final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
         commandParams.setOxdId(site.getOxdId());
-        commandParams.setAuthorizationRedirectUri(paramRedirectUrl);
+        commandParams.setRedirectUri(paramRedirectUrl);
         commandParams.setState(state);
 
         final GetAuthorizationUrlResponse resp = client.getAuthorizationUrl(Tester.getAuthorization(), commandParams);

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetLogoutUrlTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetLogoutUrlTest.java
@@ -23,12 +23,12 @@ import static junit.framework.Assert.assertTrue;
 
 public class GetLogoutUrlTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "postLogoutRedirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls", "postLogoutRedirectUrl"})
     @Test
-    public void test(String host, String opHost, String redirectUrl, String postLogoutRedirectUrl) throws IOException {
+    public void test(String host, String opHost, String redirectUrls, String postLogoutRedirectUrl) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl, postLogoutRedirectUrl, "");
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls, postLogoutRedirectUrl, "");
 
         final GetLogoutUrlParams params = new GetLogoutUrlParams();
         params.setOxdId(site.getOxdId());

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetTokensByCodeTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetTokensByCodeTest.java
@@ -25,20 +25,20 @@ import static org.junit.Assert.assertEquals;
 
 public class GetTokensByCodeTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "userId", "userSecret"})
+    @Parameters({"host", "opHost", "redirectUrls", "userId", "userSecret"})
     @Test
-    public void whenValidCodeIsUsed_shouldGetTokenInResponse(String host, String opHost, String redirectUrl, String userId, String userSecret) {
+    public void whenValidCodeIsUsed_shouldGetTokenInResponse(String host, String opHost, String redirectUrls, String userId, String userSecret) {
         ClientInterface client = Tester.newClient(host);
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         GetTokensByCodeResponse2 tokensResponse = tokenByCode(client, site, userId, userSecret, CoreUtils.secureRandomString());
         refreshToken(tokensResponse, client, site.getOxdId());
     }
 
-    @Parameters({"host", "opHost", "redirectUrl", "userId", "userSecret"})
+    @Parameters({"host", "opHost", "redirectUrls", "userId", "userSecret"})
     @Test
-    public void whenInvalidCodeIsUsed_shouldGet400BadRequest(String host, String opHost, String redirectUrl, String userId, String userSecret) {
+    public void whenInvalidCodeIsUsed_shouldGet400BadRequest(String host, String opHost, String redirectUrls, String userId, String userSecret) {
         ClientInterface client = Tester.newClient(host);
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         tokenByInvalidCode(client, site, userId, userSecret, CoreUtils.secureRandomString());
     }
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetUserInfoTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetUserInfoTest.java
@@ -20,12 +20,12 @@ import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 public class GetUserInfoTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "userId", "userSecret"})
+    @Parameters({"host", "opHost", "redirectUrls", "userId", "userSecret"})
     @Test
-    public void test(String host, String opHost, String redirectUrl, String userId, String userSecret) {
+    public void test(String host, String opHost, String redirectUrls, String userId, String userSecret) {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         final GetTokensByCodeResponse2 tokens = requestTokens(client, site, userId, userSecret);
 
         GetUserInfoParams params = new GetUserInfoParams();

--- a/oxd-server/src/test/java/org/gluu/oxd/server/IntrospectAccessTokenTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/IntrospectAccessTokenTest.java
@@ -19,13 +19,13 @@ import static org.gluu.oxd.server.TestUtils.notEmpty;
  */
 public class IntrospectAccessTokenTest {
 
-    @Parameters({"host", "opHost", "redirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls"})
     @Test
-    public void introspectAccessToken(String host, String opHost, String redirectUrl) {
+    public void introspectAccessToken(String host, String opHost, String redirectUrls) {
 
         ClientInterface client = Tester.newClient(host);
 
-        RegisterSiteResponse setupResponse = SetupClientTest.setupClient(client, opHost, redirectUrl);
+        RegisterSiteResponse setupResponse = SetupClientTest.setupClient(client, opHost, redirectUrls);
 
         final GetClientTokenParams params = new GetClientTokenParams();
         params.setOpHost(opHost);

--- a/oxd-server/src/test/java/org/gluu/oxd/server/IntrospectRptTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/IntrospectRptTest.java
@@ -18,12 +18,12 @@ import static org.testng.Assert.assertNotNull;
  */
 public class IntrospectRptTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"host", "opHost", "redirectUrls", "rsProtect"})
     @Test
-    public void test(String host, String opHost, String redirectUrl, String rsProtect) throws IOException {
+    public void test(String host, String opHost, String redirectUrls, String rsProtect) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         final RpGetRptResponse rptResponse = RpGetRptTest.requestRpt(client, site, rsProtect);
 
         IntrospectRptParams params = new IntrospectRptParams();

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
@@ -26,10 +26,10 @@ public class RegisterSiteTest {
 
     private String oxdId = null;
 
-    @Parameters({"host", "opHost", "redirectUrl", "logoutUrl", "postLogoutRedirectUrls"})
+    @Parameters({"host", "opHost", "redirectUrls", "logoutUrl", "postLogoutRedirectUrls"})
     @Test
-    public void register(String host, String opHost, String redirectUrl,  String logoutUrl, String postLogoutRedirectUrls) {
-        RegisterSiteResponse resp = registerSite(Tester.newClient(host), opHost, redirectUrl, postLogoutRedirectUrls, logoutUrl, null);
+    public void register(String host, String opHost, String redirectUrls,  String logoutUrl, String postLogoutRedirectUrls) {
+        RegisterSiteResponse resp = registerSite(Tester.newClient(host), opHost, redirectUrls, postLogoutRedirectUrls, logoutUrl);
         assertNotNull(resp);
 
         notEmpty(resp.getOxdId());
@@ -38,10 +38,9 @@ public class RegisterSiteTest {
         final RegisterSiteParams params = new RegisterSiteParams();
         //commandParams.setProtectionAccessToken(setupClient.getClientRegistrationAccessToken());
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
         params.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
         params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUrl));
-        params.setRedirectUris(Lists.newArrayList(redirectUrl));
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
         params.setAcrValues(new ArrayList<String>());
         params.setScope(Lists.newArrayList("openid", "profile"));
         params.setGrantTypes(Lists.newArrayList("authorization_code"));
@@ -102,22 +101,17 @@ public class RegisterSiteTest {
         assertNotNull(resp);
     }
 
-    public static RegisterSiteResponse registerSite(ClientInterface client, String opHost, String redirectUrl) {
-        return registerSite(client, opHost, redirectUrl, redirectUrl, "", null);
+    public static RegisterSiteResponse registerSite(ClientInterface client, String opHost, String redirectUrls) {
+        return registerSite(client, opHost, redirectUrls, redirectUrls, "");
     }
 
-    public static RegisterSiteResponse registerSite(ClientInterface client, String opHost, String redirectUrl, String postLogoutRedirectUrls, String logoutUri) {
-        return registerSite(client, opHost, redirectUrl, postLogoutRedirectUrls, logoutUri, null);
-    }
-
-    public static RegisterSiteResponse registerSite(ClientInterface client, String opHost, String redirectUrl, String postLogoutRedirectUrls, String logoutUri, List<String> redirectUris) {
+    public static RegisterSiteResponse registerSite(ClientInterface client, String opHost, String redirectUrls, String postLogoutRedirectUrls, String logoutUri) {
 
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
         params.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
         params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUri));
-        params.setRedirectUris(redirectUris);
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
         params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
         params.setTrustedClient(true);
         params.setGrantTypes(Lists.newArrayList(

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RemoveSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RemoveSiteTest.java
@@ -15,12 +15,12 @@ import static org.gluu.oxd.server.TestUtils.notEmpty;
  */
 public class RemoveSiteTest {
 
-    @Parameters({"host", "opHost", "redirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls"})
     @Test
-    public void removeSiteTest(String host, String opHost, String redirectUrl) {
+    public void removeSiteTest(String host, String opHost, String redirectUrls) {
         ClientInterface client = Tester.newClient(host);
 
-        RegisterSiteResponse resp = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse resp = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         assertNotNull(resp);
 
         notEmpty(resp.getOxdId());

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RpGetRptTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RpGetRptTest.java
@@ -26,29 +26,29 @@ import static org.testng.Assert.*;
 
 public class RpGetRptTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"host", "opHost", "redirectUrls", "rsProtect"})
     @Test
-    public void simple(String host, String opHost, String redirectUrl, String rsProtect) throws IOException {
+    public void simple(String host, String opHost, String redirectUrls, String rsProtect) throws IOException {
 
         ClientInterface client = Tester.newClient(host);
 
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
         final RpGetRptResponse response = requestRpt(client, site, rsProtect);
 
         assertNotNull(response);
     }
 
-    @Parameters({"host", "opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"host", "opHost", "redirectUrls", "rsProtect"})
     @Test
-    public void rptAsJwt(String host, String opHost, String redirectUrl, String rsProtect) throws IOException, InvalidJwtException {
+    public void rptAsJwt(String host, String opHost, String redirectUrls, String rsProtect) throws IOException, InvalidJwtException {
 
         ClientInterface client = Tester.newClient(host);
 
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
-        params.setPostLogoutRedirectUris(Lists.newArrayList(redirectUrl));
-        params.setClientFrontchannelLogoutUris(Lists.newArrayList(redirectUrl));
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
+        params.setPostLogoutRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
+        params.setClientFrontchannelLogoutUris(Lists.newArrayList(redirectUrls.split(" ")));
         params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
         params.setTrustedClient(true);
         params.setRptAsJwt(true);

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RsCheckAccessTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RsCheckAccessTest.java
@@ -18,12 +18,12 @@ import java.io.IOException;
 
 public class RsCheckAccessTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"host", "opHost", "redirectUrls", "rsProtect"})
     @Test
-    public void test(String host, String opHost, String redirectUrl, String rsProtect) throws IOException {
+    public void test(String host, String opHost, String redirectUrls, String rsProtect) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect).getResources());
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RsProtectTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RsProtectTest.java
@@ -28,24 +28,24 @@ import static junit.framework.Assert.assertNotNull;
 
 public class RsProtectTest {
 
-    @Parameters({"host", "redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"host", "redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void protect(String host, String redirectUrl, String opHost, String rsProtect) throws IOException {
+    public void protect(String host, String redirectUrls, String opHost, String rsProtect) throws IOException {
 
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         protectResources(client, site, UmaFullTest.resourceList(rsProtect).getResources());
         RsCheckAccessTest.checkAccess(client, site);
     }
 
-    @Parameters({"host", "redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"host", "redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void overwriteFalse(String host, String redirectUrl, String opHost, String rsProtect) throws IOException {
+    public void overwriteFalse(String host, String redirectUrls, String opHost, String rsProtect) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         List<RsResource> resources = UmaFullTest.resourceList(rsProtect).getResources();
         protectResources(client, site, resources);
@@ -64,12 +64,12 @@ public class RsProtectTest {
         throw new AssertionError("Expected 400 (bad request) but got successful result.");
     }
 
-    @Parameters({"host", "redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"host", "redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void overwriteTrue(String host, String redirectUrl, String opHost, String rsProtect) throws IOException {
+    public void overwriteTrue(String host, String redirectUrls, String opHost, String rsProtect) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         List<RsResource> resources = UmaFullTest.resourceList(rsProtect).getResources();
         protectResources(client, site, resources);
@@ -83,23 +83,23 @@ public class RsProtectTest {
         assertNotNull(response);
     }
 
-    @Parameters({"host", "redirectUrl", "opHost", "rsProtectScopeExpression"})
+    @Parameters({"host", "redirectUrls", "opHost", "rsProtectScopeExpression"})
     @Test
-    public void protectWithScopeExpression(String host, String redirectUrl, String opHost, String rsProtectScopeExpression) throws IOException {
+    public void protectWithScopeExpression(String host, String redirectUrls, String opHost, String rsProtectScopeExpression) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         protectResources(client, site, UmaFullTest.resourceList(rsProtectScopeExpression).getResources());
         RsCheckAccessTest.checkAccess(client, site);
     }
 
-    @Parameters({"host", "redirectUrl", "opHost", "rsProtectScopeExpressionSecond"})
+    @Parameters({"host", "redirectUrls", "opHost", "rsProtectScopeExpressionSecond"})
     @Test
-    public void protectWithScopeExpressionSeconds(String host, String redirectUrl, String opHost, String rsProtectScopeExpressionSecond) throws IOException {
+    public void protectWithScopeExpressionSeconds(String host, String redirectUrls, String opHost, String rsProtectScopeExpressionSecond) throws IOException {
         ClientInterface client = Tester.newClient(host);
 
-        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         protectResources(client, site, UmaFullTest.resourceList(rsProtectScopeExpressionSecond).getResources());
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/SetUpTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/SetUpTest.java
@@ -28,9 +28,9 @@ public class SetUpTest {
     public static DropwizardTestSupport<OxdServerConfiguration> SUPPORT = null;
 
 
-    @Parameters({"host", "opHost", "redirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls"})
     @BeforeSuite
-    public static void beforeSuite(String host, String opHost, String redirectUrl) {
+    public static void beforeSuite(String host, String opHost, String redirectUrls) {
         try {
             LOG.debug("Running beforeSuite ...");
             ServerLauncher.setSetUpSuite(true);
@@ -45,14 +45,14 @@ public class SetUpTest {
             removeExistingRps();
             LOG.debug("Existing RPs are removed.");
 
-            RegisterSiteResponse setupClient = SetupClientTest.setupClient(Tester.newClient(host), opHost, redirectUrl);
+            RegisterSiteResponse setupClient = SetupClientTest.setupClient(Tester.newClient(host), opHost, redirectUrls);
             Tester.setSetupClient(setupClient, host, opHost);
             LOG.debug("SETUP_CLIENT is set in Tester.");
 
             Preconditions.checkNotNull(Tester.getAuthorization());
             LOG.debug("Tester's authorization is set.");
 
-            setupSwaggerSuite(Tester.getTargetHost(host), opHost, redirectUrl);
+            setupSwaggerSuite(Tester.getTargetHost(host), opHost, redirectUrls);
             LOG.debug("Finished beforeSuite!");
         } catch (Exception e) {
             LOG.error("Failed to start suite.", e);
@@ -60,12 +60,12 @@ public class SetUpTest {
         }
     }
 
-    private static void setupSwaggerSuite(String host, String opHost, String redirectUrl) {
+    private static void setupSwaggerSuite(String host, String opHost, String redirectUrls) {
         try {
             if (StringUtils.countMatches(host, ":") < 2 && "http://localhost".equalsIgnoreCase(host) || "http://127.0.0.1".equalsIgnoreCase(host) ) {
                 host = host + ":" + SetUpTest.SUPPORT.getLocalPort();
             }
-            io.swagger.client.api.SetUpTest.beforeSuite(host, opHost, redirectUrl); // manual swagger tests setup
+            io.swagger.client.api.SetUpTest.beforeSuite(host, opHost, redirectUrls); // manual swagger tests setup
             io.swagger.client.api.SetUpTest.setTokenProtectionEnabled(SUPPORT.getConfiguration().getProtectCommandsWithAccessToken());
         } catch (Throwable e) {
             LOG.error("Failed to setup swagger suite.");

--- a/oxd-server/src/test/java/org/gluu/oxd/server/SetupClientTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/SetupClientTest.java
@@ -22,19 +22,18 @@ import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 public class SetupClientTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "logoutUrl", "postLogoutRedirectUrls"})
+    @Parameters({"host", "opHost", "redirectUrls", "logoutUrl", "postLogoutRedirectUrls"})
     @Test
-    public void setupClient(String host, String opHost, String redirectUrl, String logoutUrl, String postLogoutRedirectUrls) {
-        RegisterSiteResponse resp = setupClient(Tester.newClient(host), opHost, redirectUrl, postLogoutRedirectUrls, logoutUrl);
+    public void setupClient(String host, String opHost, String redirectUrls, String logoutUrl, String postLogoutRedirectUrls) {
+        RegisterSiteResponse resp = setupClient(Tester.newClient(host), opHost, redirectUrls, postLogoutRedirectUrls, logoutUrl);
         assertResponse(resp);
 
         // more specific client setup
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
         params.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
         params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUrl));
-        params.setRedirectUris(Arrays.asList(redirectUrl));
         params.setAcrValues(new ArrayList<String>());
         params.setScope(Lists.newArrayList("openid", "profile"));
         params.setGrantTypes(Lists.newArrayList("authorization_code"));
@@ -52,15 +51,15 @@ public class SetupClientTest {
         notEmpty(resp.getOxdId());
     }
 
-    public static RegisterSiteResponse setupClient(ClientInterface client, String opHost, String redirectUrl) {
-        return setupClient(client, opHost, redirectUrl, redirectUrl, "");
+    public static RegisterSiteResponse setupClient(ClientInterface client, String opHost, String redirectUrls) {
+        return setupClient(client, opHost, redirectUrls, redirectUrls, "");
     }
 
-    public static RegisterSiteResponse setupClient(ClientInterface client, String opHost, String redirectUrl, String postLogoutRedirectUrls, String logoutUri) {
+    public static RegisterSiteResponse setupClient(ClientInterface client, String opHost, String redirectUrls, String postLogoutRedirectUrls, String logoutUri) {
 
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
-        params.setAuthorizationRedirectUri(redirectUrl);
+        params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
         params.setPostLogoutRedirectUris(Lists.newArrayList(postLogoutRedirectUrls.split(" ")));
         params.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUri));
         params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));

--- a/oxd-server/src/test/java/org/gluu/oxd/server/UmaFullTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/UmaFullTest.java
@@ -23,13 +23,13 @@ import static org.testng.Assert.assertTrue;
 
 public class UmaFullTest {
 
-    @Parameters({"host", "redirectUrl", "opHost", "rsProtect"})
+    @Parameters({"host", "redirectUrls", "opHost", "rsProtect"})
     @Test
-    public void test(String host, String redirectUrl, String opHost, String rsProtect) throws Exception {
+    public void test(String host, String redirectUrls, String opHost, String rsProtect) throws Exception {
 
         ClientInterface client = Tester.newClient(host);
 
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect).getResources());
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/UmaGetClaimsGatheringUrlTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/UmaGetClaimsGatheringUrlTest.java
@@ -22,12 +22,12 @@ import static org.testng.Assert.assertTrue;
  */
 public class UmaGetClaimsGatheringUrlTest {
 
-    @Parameters({"host", "opHost", "redirectUrl", "rsProtect"})
+    @Parameters({"host", "opHost", "paramRedirectUrl", "rsProtect"})
     @Test
-    public void test(String host, String opHost, String redirectUrl, String rsProtect) throws IOException {
+    public void test(String host, String opHost, String paramRedirectUrl, String rsProtect) throws IOException {
 
         ClientInterface client = Tester.newClient(host);
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, paramRedirectUrl);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect).getResources());
 
@@ -36,7 +36,7 @@ public class UmaGetClaimsGatheringUrlTest {
         final RpGetClaimsGatheringUrlParams params = new RpGetClaimsGatheringUrlParams();
         params.setOxdId(site.getOxdId());
         params.setTicket(checkAccess.getTicket());
-        params.setClaimsRedirectUri(redirectUrl);
+        params.setClaimsRedirectUri(paramRedirectUrl);
 
         final RpGetClaimsGatheringUrlResponse response = client.umaRpGetClaimsGatheringUrl(Tester.getAuthorization(), params);
 
@@ -46,15 +46,15 @@ public class UmaGetClaimsGatheringUrlTest {
         assertTrue(StringUtils.isNotBlank(parameters.get("ticket")));
         assertTrue(StringUtils.isNotBlank(parameters.get("state")));
         assertTrue(StringUtils.isNotBlank(response.getState()));
-        assertEquals(redirectUrl, parameters.get("claims_redirect_uri"));
+        assertEquals(paramRedirectUrl, parameters.get("claims_redirect_uri"));
     }
 
-    @Parameters({"host", "opHost", "redirectUrl", "rsProtect", "state"})
+    @Parameters({"host", "opHost", "paramRedirectUrl", "rsProtect", "state"})
     @Test
-    public void testWithCustomStateParameter(String host, String opHost, String redirectUrl, String rsProtect, String state) throws IOException {
+    public void testWithCustomStateParameter(String host, String opHost, String paramRedirectUrl, String rsProtect, String state) throws IOException {
 
         ClientInterface client = Tester.newClient(host);
-        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrl);
+        RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, paramRedirectUrl);
 
         RsProtectTest.protectResources(client, site, UmaFullTest.resourceList(rsProtect).getResources());
 
@@ -63,7 +63,7 @@ public class UmaGetClaimsGatheringUrlTest {
         final RpGetClaimsGatheringUrlParams params = new RpGetClaimsGatheringUrlParams();
         params.setOxdId(site.getOxdId());
         params.setTicket(checkAccess.getTicket());
-        params.setClaimsRedirectUri(redirectUrl);
+        params.setClaimsRedirectUri(paramRedirectUrl);
         params.setState(state);
 
         final RpGetClaimsGatheringUrlResponse response = client.umaRpGetClaimsGatheringUrl(Tester.getAuthorization(), params);
@@ -74,7 +74,7 @@ public class UmaGetClaimsGatheringUrlTest {
         assertTrue(StringUtils.isNotBlank(parameters.get("ticket")));
         assertTrue(StringUtils.isNotBlank(parameters.get("state")));
         assertTrue(StringUtils.isNotBlank(response.getState()));
-        assertEquals(redirectUrl, parameters.get("claims_redirect_uri"));
+        assertEquals(paramRedirectUrl, parameters.get("claims_redirect_uri"));
         assertEquals(response.getState(), state);
     }
 }

--- a/oxd-server/src/test/java/org/gluu/oxd/server/UpdateSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/UpdateSiteTest.java
@@ -24,10 +24,10 @@ import static junit.framework.Assert.assertNotNull;
  */
 public class UpdateSiteTest {
 
-    @Parameters({"host", "opHost", "redirectUrl"})
+    @Parameters({"host", "opHost", "redirectUrls"})
     @BeforeClass
-    public static void beforeClass(String host, String opHost, String redirectUrl) {
-        SetUpTest.beforeSuite(host, opHost, redirectUrl);
+    public static void beforeClass(String host, String opHost, String redirectUrls) {
+        SetUpTest.beforeSuite(host, opHost, redirectUrls);
     }
 
     @AfterClass
@@ -45,7 +45,6 @@ public class UpdateSiteTest {
 
         final RegisterSiteParams registerParams = new RegisterSiteParams();
         registerParams.setOpHost(opHost);
-        registerParams.setAuthorizationRedirectUri(authorizationRedirectUri);
         registerParams.setClientFrontchannelLogoutUris(Lists.newArrayList(logoutUri));
         registerParams.setRedirectUris(Lists.newArrayList(authorizationRedirectUri, anotherRedirectUri, logoutUri));
         registerParams.setAcrValues(Lists.newArrayList("basic"));
@@ -61,12 +60,12 @@ public class UpdateSiteTest {
 
         Rp fetchedRp = fetchRp(host, oxdId);
 
-        assertEquals("https://client.example.com/cb", fetchedRp.getAuthorizationRedirectUri());
+        assertEquals(authorizationRedirectUri, fetchedRp.getRedirectUri());
         assertEquals(Lists.newArrayList("acrBefore"), fetchedRp.getAcrValues());
 
         final UpdateSiteParams updateParams = new UpdateSiteParams();
         updateParams.setOxdId(oxdId);
-        updateParams.setAuthorizationRedirectUri(anotherRedirectUri);
+        updateParams.setRedirectUris(Lists.newArrayList(anotherRedirectUri));
         updateParams.setScope(Lists.newArrayList("profile"));
         updateParams.setAcrValues(Lists.newArrayList("acrAfter"));
 
@@ -75,7 +74,7 @@ public class UpdateSiteTest {
 
         fetchedRp = fetchRp(host, oxdId);
 
-        assertEquals("https://client.example.com/another", fetchedRp.getAuthorizationRedirectUri());
+        assertEquals(anotherRedirectUri, fetchedRp.getRedirectUri());
         assertEquals(Lists.newArrayList("acrAfter"), fetchedRp.getAcrValues());
     }
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/manual/GoogleTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/manual/GoogleTest.java
@@ -1,6 +1,7 @@
 package org.gluu.oxd.server.manual;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import org.gluu.oxd.client.ClientInterface;
 import org.gluu.oxd.common.params.GetAuthorizationUrlParams;
 import org.gluu.oxd.common.params.RegisterSiteParams;
@@ -62,7 +63,7 @@ public class GoogleTest {
 
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(OP_HOST);
-        params.setAuthorizationRedirectUri(REDIRECT_URI);
+        params.setRedirectUris(Lists.newArrayList(REDIRECT_URI));
         params.setClientId(CLIENT_ID);
         params.setClientSecret(CLIENT_SECRET);
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/manual/NotAllowedTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/manual/NotAllowedTest.java
@@ -46,7 +46,7 @@ public class NotAllowedTest {
 
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost("https://ce-dev.gluu.org");
-        params.setAuthorizationRedirectUri("https://192.168.200.58:5053");
+        params.setRedirectUris(Lists.newArrayList("https://192.168.200.58:5053"));
         params.setScope(Lists.newArrayList("openid", "profile", "email", "address", "clientinfo", "mobile_phone", "phone", "uma_protection"));
         params.setPostLogoutRedirectUris(Lists.newArrayList("https://192.168.200.58:5053"));
         params.setClientFrontchannelLogoutUris(Lists.newArrayList("https://192.168.200.58:5053/logout"));

--- a/oxd-server/src/test/resources/testng.xml
+++ b/oxd-server/src/test/resources/testng.xml
@@ -5,7 +5,6 @@
     <parameter name="host" value="http://localhost"/>
     <parameter name="opHost" value="https://${test.server.name}"/>
     <parameter name="opDiscoveryPath" value=""/>
-    <parameter name="redirectUrl" value="https://client.example.com/cb"/>
     <parameter name="redirectUrls" value="https://client.example.com/cb/home1 https://client.example.com/cb/home2"/>
     <parameter name="paramRedirectUrl" value="https://client.example.com/cb/home2"/>
     <parameter name="postLogoutRedirectUrl" value="https://client.example.com/cb/logout"/>


### PR DESCRIPTION
#343 - Remove authorization_redirect_uri from /register-site command and make it mandatory in /get-authorization-url command

1. we drop authorization_redirect_uri and avoid confusion (which goes to the statement that it is not in Connect specs)
2. web app don’t need to remember anything, it can just put their primary redirect uri first during registration (otherwise it can provide it explicitly as parameter in the /get-authorization-url call)
