### PR TITLE
#343 - Remove authorization_redirect_uri from /register-site command

### DIFF
--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
@@ -149,7 +149,7 @@ public class RegisterSiteOperation extends BaseOperation<RegisterSiteParams> {
         params.setResponseTypes(responseTypes);
 
         // redirect_uris
-        Set<String> redirectUris = Sets.newHashSet();
+        Set<String> redirectUris = Sets.newLinkedHashSet();
         if (params.getRedirectUris() != null && !params.getRedirectUris().isEmpty() && params.getRedirectUris().stream().allMatch(uri -> Utils.isValidUrl(uri))) {
             redirectUris.addAll(params.getRedirectUris());
         } else {

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/UpdateSiteOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/UpdateSiteOperation.java
@@ -2,6 +2,7 @@ package org.gluu.oxd.server.op;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.inject.Injector;
 import org.apache.commons.lang.StringUtils;
 import org.gluu.oxd.server.Utils;
@@ -126,8 +127,7 @@ public class UpdateSiteOperation extends BaseOperation<UpdateSiteParams> {
         request.setGrantTypes(grantTypes);
         rp.setGrantType(params.getGrantType());
 
-        Set<String> redirectUris = new HashSet<>();
-
+        Set<String> redirectUris = Sets.newLinkedHashSet();
         if (params.getRedirectUris() != null && !params.getRedirectUris().isEmpty()) {
             if (!params.getRedirectUris().stream().allMatch(uri -> Utils.isValidUrl(uri))) {
                 throw new HttpException(ErrorResponseCode.INVALID_REDIRECT_URI);


### PR DESCRIPTION
#343 - Remove authorization_redirect_uri from /register-site command
https://github.com/GluuFederation/oxd/issues/343

I found that when adding `redirect_uris` to set the urls are not added in same order in HashSet.
So when testing with different URLs often it didnot redirect to first url. 
 So we have used LinkedHshSet to maintain the same order. 

