### PR TITLE
#360 - Create stress/load test which should cover all APIs with mocked OP

### DIFF
--- a/oxd-server/pom.xml
+++ b/oxd-server/pom.xml
@@ -13,6 +13,7 @@
         <h2.version>1.4.194</h2.version>
         <jedis.version>2.9.0</jedis.version>
         <dropwizard.version>1.3.1</dropwizard.version>
+        <mockito.version>1.10.19</mockito.version>
     </properties>
 
     <parent>
@@ -220,7 +221,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -442,12 +443,6 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.19.0</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/oxd-server/pom.xml
+++ b/oxd-server/pom.xml
@@ -219,7 +219,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -441,6 +442,12 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.19.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/oxd-server/src/main/java/org/gluu/oxd/server/OxdServerApplication.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/OxdServerApplication.java
@@ -39,6 +39,6 @@ public class OxdServerApplication extends Application<OxdServerConfiguration> {
             }
         });
         environment.jersey().register(RolesAllowedDynamicFeature.class);
-        environment.jersey().register(new RestResource());
+        environment.jersey().register(ServerLauncher.getInjector().getInstance(RestResource.class));
     }
 }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Processor.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Processor.java
@@ -4,6 +4,7 @@
 package org.gluu.oxd.server;
 
 import com.google.inject.Inject;
+import org.gluu.oxd.server.op.OpClientFactory;
 import org.jboss.resteasy.client.ClientResponseFailure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,10 +37,10 @@ public class Processor {
         this.validationService = validationService;
     }
 
-    public IOpResponse process(Command command) {
+    public IOpResponse process(Command command, OpClientFactory opClientFactory) {
         if (command != null) {
             try {
-                final IOperation<IParams> operation = (IOperation<IParams>) OperationFactory.create(command, ServerLauncher.getInjector());
+                final IOperation<IParams> operation = (IOperation<IParams>) OperationFactory.create(command, ServerLauncher.getInjector(), opClientFactory);
                 if (operation != null) {
                     IParams iParams = Convertor.asParams(operation.getParameterClass(), command);
                     validationService.validate(iParams);

--- a/oxd-server/src/main/java/org/gluu/oxd/server/guice/GuiceModule.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/guice/GuiceModule.java
@@ -5,7 +5,11 @@ package org.gluu.oxd.server.guice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 import org.gluu.oxd.server.OxdServerConfiguration;
+import org.gluu.oxd.server.op.OpClientFactory;
+import org.gluu.oxd.server.op.OpClientFactoryImpl;
+import org.gluu.oxd.server.op.RegisterSiteOperation;
 import org.gluu.oxd.server.persistence.H2PersistenceProvider;
 import org.gluu.oxd.server.persistence.PersistenceService;
 import org.gluu.oxd.server.persistence.PersistenceServiceImpl;
@@ -34,5 +38,6 @@ public class GuiceModule extends AbstractModule {
         bind(DiscoveryService.class).in(Singleton.class);
         bind(ValidationService.class).in(Singleton.class);
         bind(StateService.class).in(Singleton.class);
+        bind(OpClientFactory.class).to(OpClientFactoryImpl.class).in(Singleton.class);
     }
 }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/GetClientTokenOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/GetClientTokenOperation.java
@@ -31,13 +31,15 @@ public class GetClientTokenOperation extends BaseOperation<GetClientTokenParams>
 
     private static final Logger LOG = LoggerFactory.getLogger(GetClientTokenOperation.class);
 
+    private OpClientFactory opClientFactory;
     /**
      * Base constructor
      *
      * @param command command
      */
-    protected GetClientTokenOperation(Command command, final Injector injector) {
+    protected GetClientTokenOperation(Command command, final Injector injector, OpClientFactory opClientFactory) {
         super(command, injector, GetClientTokenParams.class);
+        this.opClientFactory = opClientFactory;
     }
 
     @Override
@@ -45,7 +47,8 @@ public class GetClientTokenOperation extends BaseOperation<GetClientTokenParams>
         try {
             final AuthenticationMethod authenticationMethod = AuthenticationMethod.fromString(params.getAuthenticationMethod());
             final String tokenEndpoint = getDiscoveryService().getConnectDiscoveryResponse(params.getOpHost(), params.getOpDiscoveryPath()).getTokenEndpoint();
-            final TokenClient tokenClient = new TokenClient(tokenEndpoint);
+            //final TokenClient tokenClient = new TokenClient(tokenEndpoint);
+            final TokenClient tokenClient = opClientFactory.createTokenClient(tokenEndpoint);
             tokenClient.setExecutor(getHttpService().getClientExecutor());
 
             final TokenResponse tokenResponse;

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/OpClientFactory.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/OpClientFactory.java
@@ -1,0 +1,15 @@
+package org.gluu.oxd.server.op;
+
+import org.gluu.oxauth.client.*;
+
+public interface OpClientFactory {
+    public TokenClient createTokenClient(String url);
+
+    public UserInfoClient createUserInfoClient(String url);
+
+    public RegisterClient createRegisterClient(String url);
+
+    public OpenIdConfigurationClient createOpenIdConfigurationClient(String url);
+
+    public AuthorizeClient createAuthorizeClient(String url);
+}

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/OpClientFactoryImpl.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/OpClientFactoryImpl.java
@@ -1,0 +1,30 @@
+package org.gluu.oxd.server.op;
+
+import org.gluu.oxauth.client.*;
+
+public class OpClientFactoryImpl implements OpClientFactory {
+
+    public OpClientFactoryImpl() {
+    }
+
+    public TokenClient createTokenClient(String url) {
+        return new TokenClient(url);
+    }
+
+    public UserInfoClient createUserInfoClient(String url) {
+        return new UserInfoClient(url);
+    }
+
+    public RegisterClient createRegisterClient(String url) {
+        return new RegisterClient(url);
+    }
+
+    public OpenIdConfigurationClient createOpenIdConfigurationClient(String url) {
+        return new OpenIdConfigurationClient(url);
+    }
+
+    public AuthorizeClient createAuthorizeClient(String url) {
+        return new AuthorizeClient(url);
+    }
+
+}

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/OperationFactory.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/OperationFactory.java
@@ -4,6 +4,7 @@
 package org.gluu.oxd.server.op;
 
 import com.google.inject.Injector;
+import org.gluu.oxd.server.ServerLauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.gluu.oxd.common.Command;
@@ -21,7 +22,7 @@ public class OperationFactory {
     private OperationFactory() {
     }
 
-    public static IOperation<? extends IParams> create(Command command, final Injector injector) {
+    public static IOperation<? extends IParams> create(Command command, final Injector injector, OpClientFactory opClientFactory) {
         if (command != null && command.getCommandType() != null) {
             switch (command.getCommandType()) {
                 case AUTHORIZATION_CODE_FLOW:
@@ -43,7 +44,7 @@ public class OperationFactory {
                 case GET_ACCESS_TOKEN_BY_REFRESH_TOKEN:
                     return new GetAccessTokenByRefreshTokenOperation(command, injector);
                 case REGISTER_SITE:
-                    return new RegisterSiteOperation(command, injector);
+                    return new RegisterSiteOperation(command, injector, opClientFactory);
                 case GET_AUTHORIZATION_CODE:
                     return new GetAuthorizationCodeOperation(command, injector);
                 case GET_LOGOUT_URI:
@@ -59,7 +60,7 @@ public class OperationFactory {
                 case RP_GET_CLAIMS_GATHERING_URL:
                     return new RpGetGetClaimsGatheringUrlOperation(command, injector);
                 case GET_CLIENT_TOKEN:
-                    return new GetClientTokenOperation(command, injector);
+                    return new GetClientTokenOperation(command, injector, opClientFactory);
                 case INTROSPECT_ACCESS_TOKEN:
                     return new IntrospectAccessTokenOperation(command, injector);
                 case INTROSPECT_RPT:

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
@@ -20,6 +20,7 @@ import org.gluu.oxauth.model.crypto.signature.SignatureAlgorithm;
 import org.gluu.oxauth.model.register.ApplicationType;
 import org.gluu.oxauth.model.uma.UmaMetadata;
 import org.gluu.oxd.common.Command;
+import org.gluu.oxd.common.CommandType;
 import org.gluu.oxd.common.ErrorResponseCode;
 import org.gluu.oxd.common.params.RegisterSiteParams;
 import org.gluu.oxd.common.response.IOpResponse;
@@ -39,20 +40,22 @@ import java.util.UUID;
 /**
  * @author Yuriy Zabrovarnyy
  */
-
 public class RegisterSiteOperation extends BaseOperation<RegisterSiteParams> {
 
     private static final Logger LOG = LoggerFactory.getLogger(RegisterSiteOperation.class);
 
     private Rp rp;
 
+    private OpClientFactory opClientFactory;
+
     /**
      * Base constructor
      *
      * @param command command
      */
-    protected RegisterSiteOperation(Command command, final Injector injector) {
+    protected RegisterSiteOperation(Command command, final Injector injector, OpClientFactory opClientFactory) {
         super(command, injector, RegisterSiteParams.class);
+        this.opClientFactory = opClientFactory;
     }
 
     public RegisterSiteResponse execute_(RegisterSiteParams params) {
@@ -245,7 +248,8 @@ public class RegisterSiteOperation extends BaseOperation<RegisterSiteParams> {
             throw new HttpException(ErrorResponseCode.NO_REGISTRATION_ENDPOINT);
         }
 
-        final RegisterClient registerClient = new RegisterClient(registrationEndpoint);
+        //final RegisterClient registerClient = new RegisterClient(registrationEndpoint);
+        final RegisterClient registerClient = opClientFactory.createRegisterClient(registrationEndpoint);
         registerClient.setRequest(createRegisterClientRequest(params));
         registerClient.setExecutor(getHttpService().getClientExecutor());
         final RegisterResponse response = registerClient.exec();

--- a/oxd-server/src/test/java/org/gluu/oxd/server/mock/op/MockSetUpTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/mock/op/MockSetUpTest.java
@@ -1,0 +1,105 @@
+package org.gluu.oxd.server.mock.op;
+
+import com.google.common.base.Preconditions;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.dropwizard.testing.ResourceHelpers;
+import org.apache.commons.lang.StringUtils;
+import org.gluu.oxd.common.response.RegisterSiteResponse;
+import org.gluu.oxd.server.*;
+import org.gluu.oxd.server.persistence.PersistenceService;
+import org.gluu.oxd.server.service.RpService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Parameters;
+
+/**
+ * Main class to set up and tear down suite.
+ *
+ * @author Yuriy Zabrovarnyy
+ * @version 0.9, 21/08/2013
+ */
+
+public class MockSetUpTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SetUpTest.class);
+
+    public static DropwizardTestSupport<OxdServerConfiguration> SUPPORT = null;
+
+
+    @Parameters({"host", "opHost", "redirectUrls"})
+    @BeforeSuite
+    public static void beforeSuite(String host, String opHost, String redirectUrls) {
+        try {
+            LOG.debug("Running beforeSuite ...");
+            ServerLauncher.setSetUpSuite(true);
+
+            SUPPORT = new DropwizardTestSupport<OxdServerConfiguration>(OxdServerApplication.class,
+                    ResourceHelpers.resourceFilePath("oxd-server-jenkins.yml"),
+                    ConfigOverride.config("server.applicationConnectors[0].port", "0") // Optional, if not using a separate testing-specific configuration file, use a randomly selected port
+            );
+            SUPPORT.before();
+            LOG.debug("HTTP server started.");
+
+            setOpClientFactory();
+            LOG.debug("HTTP server started.");
+
+            removeExistingRps();
+            LOG.debug("Existing RPs are removed.");
+
+            RegisterSiteResponse setupClient = SetupClientTest.setupClient(MockTester.newClient(host), opHost, redirectUrls);
+            MockTester.setSetupClient(setupClient, host, opHost);
+            LOG.debug("SETUP_CLIENT is set in Tester.");
+
+            Preconditions.checkNotNull(MockTester.getAuthorization());
+            LOG.debug("Tester's authorization is set.");
+
+            setupSwaggerSuite(MockTester.getTargetHost(host), opHost, redirectUrls);
+            LOG.debug("Finished beforeSuite!");
+        } catch (Exception e) {
+            LOG.error("Failed to start suite.", e);
+            throw new AssertionError("Failed to start suite.");
+        }
+    }
+
+    private static void setOpClientFactory() {
+        ServerLauncher.getInjector().getInstance(RestResource.class).setOpClientFactory(new OpClientFactoryStubImpl());
+    }
+    private static void setupSwaggerSuite(String host, String opHost, String redirectUrls) {
+        try {
+            if (StringUtils.countMatches(host, ":") < 2 && "http://localhost".equalsIgnoreCase(host) || "http://127.0.0.1".equalsIgnoreCase(host) ) {
+                host = host + ":" + SetUpTest.SUPPORT.getLocalPort();
+            }
+            io.swagger.client.api.SetUpTest.beforeSuite(host, opHost, redirectUrls); // manual swagger tests setup
+            io.swagger.client.api.SetUpTest.setTokenProtectionEnabled(SUPPORT.getConfiguration().getProtectCommandsWithAccessToken());
+        } catch (Throwable e) {
+            LOG.error("Failed to setup swagger suite.");
+        }
+    }
+
+    private static void removeExistingRps() {
+        try {
+            ServerLauncher.getInjector().getInstance(PersistenceService.class).create();
+            ServerLauncher.getInjector().getInstance(RpService.class).removeAllRps();
+            ServerLauncher.getInjector().getInstance(RpService.class).load();
+            LOG.debug("Finished removeExistingRps successfullly.");
+        } catch (Exception e) {
+            LOG.error("Failed to removed existing RPs.", e);
+        }
+    }
+
+    @AfterSuite
+    public static void afterSuite() {
+        try {
+            LOG.debug("Running afterSuite ...");
+            SUPPORT.after();
+            ServerLauncher.shutdown(false);
+            LOG.debug("HTTP server is successfully stopped.");
+        } catch (Exception e) {
+            LOG.error("Failed to stop HTTP server.", e);
+        }
+    }
+
+}

--- a/oxd-server/src/test/java/org/gluu/oxd/server/mock/op/MockTester.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/mock/op/MockTester.java
@@ -1,0 +1,72 @@
+package org.gluu.oxd.server.mock.op;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
+import org.gluu.oxd.client.ClientInterface;
+import org.gluu.oxd.client.OxdClient;
+import org.gluu.oxd.common.params.GetClientTokenParams;
+import org.gluu.oxd.common.response.GetClientTokenResponse;
+import org.gluu.oxd.common.response.RegisterSiteResponse;
+
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * @author Yuriy Zabrovarnyy
+ * @version 0.9, 05/10/2015
+ */
+
+public class MockTester {
+
+    private MockTester() {
+    }
+
+    private static String AUTHORIZATION = "";
+    private static RegisterSiteResponse SETUP_CLIENT;
+    private static String HOST;
+    private static String OP_HOST;
+
+    public static ClientInterface newClient(String targetHost) {
+        return OxdClient.newClient(getTargetHost(targetHost));
+    }
+
+    public static String getTargetHost(String targetHost) {
+        if (StringUtils.countMatches(targetHost, ":") < 2 && "http://localhost".equalsIgnoreCase(targetHost) || "http://127.0.0.1".equalsIgnoreCase(targetHost) ) {
+            targetHost = targetHost + ":" + MockSetUpTest.SUPPORT.getLocalPort();
+        }
+        if ("localhost".equalsIgnoreCase(targetHost)) {
+            targetHost = "http://localhost:" + MockSetUpTest.SUPPORT.getLocalPort();
+        }
+        return targetHost;
+    }
+
+    public static String getAuthorization() {
+        Preconditions.checkNotNull(SETUP_CLIENT);
+        if (Strings.isNullOrEmpty(AUTHORIZATION)) {
+            final GetClientTokenParams params = new GetClientTokenParams();
+            params.setOpHost(OP_HOST);
+            params.setScope(Lists.newArrayList("openid"));
+            params.setClientId(MockTester.getSetupClient().getClientId());
+            params.setClientSecret(MockTester.getSetupClient().getClientSecret());
+
+            GetClientTokenResponse resp = MockTester.newClient(HOST).getClientToken(params);
+            assertNotNull(resp);
+            assertTrue(!Strings.isNullOrEmpty(resp.getAccessToken()));
+
+            AUTHORIZATION = "Bearer " + resp.getAccessToken();
+        }
+        return AUTHORIZATION;
+    }
+
+    public static RegisterSiteResponse getSetupClient() {
+        return SETUP_CLIENT;
+    }
+
+    public static void setSetupClient(RegisterSiteResponse setupClient, String host, String opHost) {
+        SETUP_CLIENT = setupClient;
+        HOST = host;
+        OP_HOST = opHost;
+    }
+}

--- a/oxd-server/src/test/java/org/gluu/oxd/server/mock/op/OpClientFactoryStubImpl.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/mock/op/OpClientFactoryStubImpl.java
@@ -1,0 +1,73 @@
+package org.gluu.oxd.server.mock.op;
+
+import org.assertj.core.util.Lists;
+import org.gluu.oxauth.client.*;
+import org.gluu.oxauth.model.common.GrantType;
+import org.gluu.oxauth.model.common.TokenType;
+import org.gluu.oxd.server.op.OpClientFactory;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OpClientFactoryStubImpl implements OpClientFactory {
+    @Override
+    public TokenClient createTokenClient(String url) {
+        TokenClient client = mock(TokenClient.class);
+
+        TokenResponse response = new TokenResponse();
+        response.setAccessToken("DUMMY_ACCESS_TOKEN_"+ System.currentTimeMillis());
+        response.setTokenType(TokenType.BEARER);
+        response.setExpiresIn(299);
+        response.setRefreshToken(null);
+        response.setScope("openid");
+        response.setIdToken(null);
+
+        when(client.exec()).thenReturn(response);
+        when(client.execClientCredentialsGrant(any(), any(), any())).thenReturn(response);
+
+        return client;
+    }
+
+    @Override
+    public UserInfoClient createUserInfoClient(String url) {
+        return null;
+    }
+
+    @Override
+    public RegisterClient createRegisterClient(String url) {
+        RegisterClient client = mock(RegisterClient.class);
+
+        RegisterResponse response = new RegisterResponse();
+        response.setClientId("DUMMY_CLIENT_ID_"+ System.currentTimeMillis());
+        response.setClientSecret("DUMMY_CLIENT_SECRET_"+ System.currentTimeMillis());
+        response.setRegistrationAccessToken("DUMMY_REGISTRATION_ACCESS_TOKEN");
+        response.setRegistrationClientUri("https://www.dummy-op-server.xyz/oxauth/restv1/register?client_id=@!8DBF.24EB.FA0E.1BFF!0001!32B7.932A!0008!AB90.6BF3.8E32.7A13");
+
+        Calendar calendar = Calendar.getInstance();
+        // get a date to represent "today"
+        Date today = calendar.getTime();
+        // add one day to the date/calendar
+        calendar.add(Calendar.DAY_OF_YEAR, 1);
+        Date tomorrow = calendar.getTime();
+
+        response.setClientIdIssuedAt(today);
+        response.setClientIdIssuedAt(tomorrow);
+
+        when(client.exec()).thenReturn(response);
+        return client;
+    }
+
+    @Override
+    public OpenIdConfigurationClient createOpenIdConfigurationClient(String url) {
+        return null;
+    }
+
+    @Override
+    public AuthorizeClient createAuthorizeClient(String url) {
+        return null;
+    }
+}


### PR DESCRIPTION
#360 - Create stress/load test which should cover all APIs with mocked OP
https://github.com/GluuFederation/oxd/issues/360

We have written mocks for `RegisterClient` and `TokenClient`. and running test cases for `RegisterSiteOperation` and `GetClientTokenOperation`

Could you please verify if we are going in right direction. If yes then we can implement same for all the clients.