### PR TITLE
#371 - Persist field only if it's not null into oxd db to avoid saving redundant data

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/Jackson2.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/Jackson2.java
@@ -1,5 +1,6 @@
 package org.gluu.oxd.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import org.slf4j.Logger;
@@ -44,6 +45,18 @@ public class Jackson2 {
 
     public static String asJson(Object p_object) throws IOException {
         final ObjectMapper mapper = createJsonMapper().configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        return mapper.writeValueAsString(p_object);
+    }
+
+    public static ObjectMapper createRpMapper() {
+        final ObjectMapper mapper = createJsonMapper().configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        return mapper;
+    }
+
+    public static String serializeWithoutNulls(Object p_object) throws IOException {
+        final ObjectMapper mapper = createRpMapper();
         return mapper.writeValueAsString(p_object);
     }
 

--- a/oxd-server/src/main/java/org/gluu/oxd/server/persistence/RedisPersistenceService.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/persistence/RedisPersistenceService.java
@@ -47,7 +47,7 @@ public class RedisPersistenceService implements PersistenceService {
     @Override
     public boolean create(Rp rp) {
         try {
-            put(rp.getOxdId(), Jackson2.asJson(rp));
+            put(rp.getOxdId(), Jackson2.serializeWithoutNulls(rp));
             return true;
         } catch (IOException e) {
             LOG.error("Failed to create RP: " + rp, e);
@@ -58,7 +58,7 @@ public class RedisPersistenceService implements PersistenceService {
     @Override
     public boolean update(Rp rp) {
         try {
-            put(rp.getOxdId(), Jackson2.asJson(rp));
+            put(rp.getOxdId(), Jackson2.serializeWithoutNulls(rp));
             return true;
         } catch (IOException e) {
             LOG.error("Failed to create RP: " + rp, e);

--- a/oxd-server/src/main/java/org/gluu/oxd/server/persistence/SqlPersistenceServiceImpl.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/persistence/SqlPersistenceServiceImpl.java
@@ -64,7 +64,7 @@ public class SqlPersistenceServiceImpl implements PersistenceService {
             conn.setAutoCommit(false);
             PreparedStatement query = conn.prepareStatement("insert into rp(id, data) values(?, ?)");
             query.setString(1, rp.getOxdId());
-            query.setString(2, Jackson2.asJson(rp));
+            query.setString(2, Jackson2.serializeWithoutNulls(rp));
             query.executeUpdate();
             query.close();
 
@@ -86,7 +86,7 @@ public class SqlPersistenceServiceImpl implements PersistenceService {
             conn = provider.getConnection();
             conn.setAutoCommit(false);
             PreparedStatement query = conn.prepareStatement("update rp set data = ? where id = ?");
-            query.setString(1, Jackson2.asJson(rp));
+            query.setString(1, Jackson2.serializeWithoutNulls(rp));
             query.setString(2, rp.getOxdId());
             query.executeUpdate();
             query.close();

--- a/oxd-server/src/main/java/org/gluu/oxd/server/service/Rp.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/service/Rp.java
@@ -83,7 +83,7 @@ public class Rp implements Serializable {
     @JsonProperty(value = "pat")
     private String pat;
     @JsonProperty(value = "pat_expires_in")
-    private int patExpiresIn;
+    private Integer patExpiresIn;
     @JsonProperty(value = "pat_created_at")
     private Date patCreatedAt;
     @JsonProperty(value = "pat_refresh_token")
@@ -93,7 +93,7 @@ public class Rp implements Serializable {
     @JsonProperty(value = "oauth_token")
     private String oauthToken;
     @JsonProperty(value = "oauth_token_expires_in")
-    private int oauthTokenExpiresIn;
+    private Integer oauthTokenExpiresIn;
     @JsonProperty(value = "oauth_token_created_at")
     private Date oauthTokenCreatedAt;
     @JsonProperty(value = "oauth_token_refresh_token")
@@ -373,11 +373,11 @@ public class Rp implements Serializable {
         this.pat = pat;
     }
 
-    public int getPatExpiresIn() {
+    public Integer getPatExpiresIn() {
         return patExpiresIn;
     }
 
-    public void setPatExpiresIn(int patExpiresIn) {
+    public void setPatExpiresIn(Integer patExpiresIn) {
         this.patExpiresIn = patExpiresIn;
     }
 
@@ -397,11 +397,11 @@ public class Rp implements Serializable {
         this.oauthToken = oauthToken;
     }
 
-    public int getOauthTokenExpiresIn() {
+    public Integer getOauthTokenExpiresIn() {
         return oauthTokenExpiresIn;
     }
 
-    public void setOauthTokenExpiresIn(int oauthTokenExpiresIn) {
+    public void setOauthTokenExpiresIn(Integer oauthTokenExpiresIn) {
         this.oauthTokenExpiresIn = oauthTokenExpiresIn;
     }
 

--- a/oxd-server/src/main/java/org/gluu/oxd/server/service/UmaTokenService.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/service/UmaTokenService.java
@@ -173,7 +173,7 @@ public class UmaTokenService {
 
         Rp site = rpService.getRp(oxdId);
 
-        if (site.getPat() != null && site.getPatCreatedAt() != null && site.getPatExpiresIn() > 0) {
+        if (site.getPat() != null && site.getPatCreatedAt() != null && site.getPatExpiresIn() != null && site.getPatExpiresIn() > 0) {
             Calendar expiredAt = Calendar.getInstance();
             expiredAt.setTime(site.getPatCreatedAt());
             expiredAt.add(Calendar.SECOND, site.getPatExpiresIn());
@@ -206,7 +206,7 @@ public class UmaTokenService {
 
         Rp site = rpService.getRp(oxdId);
 
-        if (site.getOauthToken() != null && site.getOauthTokenCreatedAt() != null && site.getOauthTokenExpiresIn() > 0) {
+        if (site.getOauthToken() != null && site.getOauthTokenCreatedAt() != null && site.getOauthTokenExpiresIn() != null && site.getOauthTokenExpiresIn() > 0) {
             Calendar expiredAt = Calendar.getInstance();
             expiredAt.setTime(site.getOauthTokenCreatedAt());
             expiredAt.add(Calendar.SECOND, site.getOauthTokenExpiresIn());

--- a/oxd-server/src/test/resources/testng.xml
+++ b/oxd-server/src/test/resources/testng.xml
@@ -101,6 +101,11 @@
             <class name="org.gluu.oxd.server.AccessTokenAsJwtTest"/>
         </classes>
     </test>
+    <test name="rp" enabled="true">
+        <classes>
+            <class name="org.gluu.oxd.server.service.RpServiceTest"/>
+        </classes>
+    </test>
 
     <!-- UMA Tests -->
     <test name="UMA - Full Flow Test" enabled="true">


### PR DESCRIPTION
#371 - Persist field only if it's not null into oxd db to avoid saving redundant data
https://github.com/GluuFederation/oxd/issues/371

Note : Added both JsonInclude.Include.NON_NULL and JsonInclude.Include.NON_EMPTY. JsonInclude.Include.NON_EMPTY added to remove empty strings and array. 