### PR TITLE
#396 - Upgrade `Dropwizard` dependency from version `1.3.1` to `2.0.0` in oxd

### DIFF
--- a/oxd-gen-client/src/test/java/io/swagger/client/api/GetTokensByCodeTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/GetTokensByCodeTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 import org.gluu.oxd.common.CoreUtils;
 
 import static io.swagger.client.api.Tester.notEmpty;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.*;
 
 /**
  * Test class to test refresh token and related end points

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/IntrospectAccessTokenTest.java
@@ -7,7 +7,7 @@ import io.swagger.client.model.*;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.*;
+import static org.testng.Assert.*;
 
 /**
  * @author yuriyz

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/RemoveSiteTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/RemoveSiteTest.java
@@ -11,7 +11,7 @@ import org.gluu.oxd.common.ErrorResponseCode;
 
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.testng.Assert.*;
 
 public class RemoveSiteTest {
 

--- a/oxd-server/pom.xml
+++ b/oxd-server/pom.xml
@@ -13,6 +13,7 @@
         <h2.version>1.4.194</h2.version>
         <jedis.version>2.9.0</jedis.version>
         <dropwizard.version>2.0.0</dropwizard.version>
+        <jersey-test-framework-provider>2.29.1</jersey-test-framework-provider>
     </properties>
 
     <parent>
@@ -220,7 +221,7 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-configuration</artifactId>
-            <version>2.0.0</version>
+            <version>${dropwizard.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>commons-text</artifactId>
@@ -237,7 +238,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-inmemory</artifactId>
-            <version>2.29.1</version>
+            <version>${jersey-test-framework-provider}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -261,7 +262,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
-            <version>2.29.1</version>
+            <version>${jersey-test-framework-provider}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/oxd-server/pom.xml
+++ b/oxd-server/pom.xml
@@ -202,6 +202,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.8</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -212,6 +217,12 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -222,12 +233,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-configuration</artifactId>
             <version>${dropwizard.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>commons-text</artifactId>
-                    <groupId>org.apache.commons</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -321,10 +326,6 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
-                <exclusion>
-                    <artifactId>commons-text</artifactId>
-                    <groupId>org.apache.commons</groupId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -392,12 +393,6 @@
         <dependency>
             <groupId>org.gluu</groupId>
             <artifactId>oxcore-util</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>commons-text</artifactId>
-                    <groupId>org.apache.commons</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.gluu</groupId>
@@ -431,17 +426,13 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
-        </dependency>
-        <dependency>
-            <artifactId>commons-text</artifactId>
-            <groupId>org.apache.commons</groupId>
-            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing.contrib</groupId>

--- a/oxd-server/pom.xml
+++ b/oxd-server/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <h2.version>1.4.194</h2.version>
         <jedis.version>2.9.0</jedis.version>
-        <dropwizard.version>1.3.1</dropwizard.version>
+        <dropwizard.version>2.0.0</dropwizard.version>
     </properties>
 
     <parent>
@@ -218,13 +218,26 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-configuration</artifactId>
+            <version>2.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-text</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>3.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-inmemory</artifactId>
+            <version>2.29.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -248,6 +261,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <version>2.29.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -305,6 +319,10 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>commons-text</artifactId>
+                    <groupId>org.apache.commons</groupId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -373,6 +391,12 @@
         <dependency>
             <groupId>org.gluu</groupId>
             <artifactId>oxcore-util</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-text</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.gluu</groupId>
@@ -412,6 +436,11 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
+        </dependency>
+        <dependency>
+            <artifactId>commons-text</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing.contrib</groupId>

--- a/oxd-server/src/main/java/org/gluu/oxd/server/OxdServerApplication.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/OxdServerApplication.java
@@ -40,6 +40,6 @@ public class OxdServerApplication extends Application<OxdServerConfiguration> {
             }
         });
         environment.jersey().register(RolesAllowedDynamicFeature.class);
-        environment.jersey().register(new RestResource());
+        environment.jersey().register(RestResource.class);
     }
 }

--- a/oxd-server/src/test/java/org/gluu/oxd/mock/AuthorizationCodeFlowTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/mock/AuthorizationCodeFlowTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 import java.util.UUID;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 /**

--- a/oxd-server/src/test/java/org/gluu/oxd/server/AccessTokenAsJwtTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/AccessTokenAsJwtTest.java
@@ -11,7 +11,7 @@ import org.gluu.oxd.common.response.RegisterSiteResponse;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.SetupClientTest.assertResponse;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/CheckIdTokenTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/CheckIdTokenTest.java
@@ -12,8 +12,8 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Yuriy Zabrovarnyy

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetClientTokenTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetClientTokenTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 import org.gluu.oxd.common.params.GetClientTokenParams;
 import org.gluu.oxd.common.response.GetClientTokenResponse;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 /**

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetLogoutUrlTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetLogoutUrlTest.java
@@ -11,8 +11,8 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.UUID;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Dummy test because we can't check real session management which is handled via browser cookies.

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetTokensByCodeTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetTokensByCodeTest.java
@@ -14,9 +14,9 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.BadRequestException;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Yuriy Zabrovarnyy

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetUserInfoTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetUserInfoTest.java
@@ -10,7 +10,7 @@ import org.gluu.oxd.common.response.RegisterSiteResponse;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 /**

--- a/oxd-server/src/test/java/org/gluu/oxd/server/HealthCheckTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/HealthCheckTest.java
@@ -3,8 +3,8 @@ package org.gluu.oxd.server;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
 
 public class HealthCheckTest {
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/IntrospectAccessTokenTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/IntrospectAccessTokenTest.java
@@ -10,8 +10,8 @@ import org.gluu.oxd.common.response.GetClientTokenResponse;
 import org.gluu.oxd.common.response.IntrospectAccessTokenResponse;
 import org.gluu.oxd.common.response.RegisterSiteResponse;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 /**

--- a/oxd-server/src/test/java/org/gluu/oxd/server/IntrospectRptTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/IntrospectRptTest.java
@@ -10,7 +10,7 @@ import org.gluu.oxd.common.response.RpGetRptResponse;
 
 import java.io.IOException;
 
-import static junit.framework.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.Assert.assertNotNull;
 
 /**

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RegisterRequestMapperTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RegisterRequestMapperTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.stream.Collectors;
 
-import static junit.framework.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 public class RegisterRequestMapperTest {
 

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
@@ -16,8 +16,8 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 /**

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RemoveSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RemoveSiteTest.java
@@ -7,7 +7,7 @@ import org.gluu.oxd.common.params.RemoveSiteParams;
 import org.gluu.oxd.common.response.RegisterSiteResponse;
 import org.gluu.oxd.common.response.RemoveSiteResponse;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 /**

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RpGetRptTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RpGetRptTest.java
@@ -2,7 +2,6 @@ package org.gluu.oxd.server;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import junit.framework.Assert;
 import org.apache.commons.lang.StringUtils;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -18,8 +17,9 @@ import org.gluu.oxd.common.response.RsCheckAccessResponse;
 
 import java.io.IOException;
 
-import static org.testng.Assert.*;
-
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
 /**
  * @author Yuriy Zabrovarnyy
  */
@@ -58,8 +58,8 @@ public class RpGetRptTest {
                 GrantType.CLIENT_CREDENTIALS.getValue()));
 
         final RegisterSiteResponse site = client.registerSite(params);
-        Assert.assertNotNull(site);
-        Assert.assertTrue(!Strings.isNullOrEmpty(site.getOxdId()));
+        assertNotNull(site);
+        assertTrue(!Strings.isNullOrEmpty(site.getOxdId()));
 
         final RpGetRptResponse response = requestRpt(client, site, rsProtect);
         assertNotNull(response);

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RsCheckAccessTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RsCheckAccessTest.java
@@ -1,6 +1,5 @@
 package org.gluu.oxd.server;
 
-import junit.framework.Assert;
 import org.apache.commons.lang.StringUtils;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -10,7 +9,8 @@ import org.gluu.oxd.common.response.RegisterSiteResponse;
 import org.gluu.oxd.common.response.RsCheckAccessResponse;
 
 import java.io.IOException;
-
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 /**
  * @author Yuriy Zabrovarnyy
  * @version 0.9, 03/07/2017
@@ -39,8 +39,8 @@ public class RsCheckAccessTest {
 
         final RsCheckAccessResponse response = client.umaRsCheckAccess(Tester.getAuthorization(), params);
 
-        Assert.assertNotNull(response);
-        Assert.assertTrue(StringUtils.isNotBlank(response.getAccess()));
+        assertNotNull(response);
+        assertTrue(StringUtils.isNotBlank(response.getAccess()));
         return response;
     }
 }

--- a/oxd-server/src/test/java/org/gluu/oxd/server/RsProtectTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RsProtectTest.java
@@ -1,6 +1,5 @@
 package org.gluu.oxd.server;
 
-import junit.framework.Assert;
 import org.apache.commons.lang.StringUtils;
 import org.gluu.oxd.common.Jackson2;
 import org.gluu.oxd.server.op.RsProtectOperation;
@@ -18,8 +17,9 @@ import javax.ws.rs.BadRequestException;
 import java.io.IOException;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Yuriy Zabrovarnyy
@@ -111,8 +111,8 @@ public class RsProtectTest {
 
         final RsCheckAccessResponse response = client.umaRsCheckAccess(Tester.getAuthorization(), params);
 
-        Assert.assertNotNull(response);
-        Assert.assertTrue(StringUtils.isNotBlank(response.getAccess()));
+        assertNotNull(response);
+        assertTrue(StringUtils.isNotBlank(response.getAccess()));
     }
 
     public static RsProtectResponse protectResources(ClientInterface client, RegisterSiteResponse site, List<RsResource> resources) {

--- a/oxd-server/src/test/java/org/gluu/oxd/server/SetupClientTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/SetupClientTest.java
@@ -1,18 +1,16 @@
 package org.gluu.oxd.server;
 
 import com.google.common.collect.Lists;
-import org.testng.annotations.Parameters;
-import org.testng.annotations.Test;
 import org.gluu.oxauth.model.common.GrantType;
 import org.gluu.oxd.client.ClientInterface;
 import org.gluu.oxd.common.params.RegisterSiteParams;
 import org.gluu.oxd.common.response.RegisterSiteResponse;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 /**

--- a/oxd-server/src/test/java/org/gluu/oxd/server/TestUtils.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/TestUtils.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import static junit.framework.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Yuriy Zabrovarnyy

--- a/oxd-server/src/test/java/org/gluu/oxd/server/UpdateSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/UpdateSiteTest.java
@@ -16,8 +16,8 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * @author Yuriy Zabrovarnyy

--- a/oxd-server/src/test/java/org/gluu/oxd/server/UtilsTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/UtilsTest.java
@@ -1,10 +1,9 @@
 package org.gluu.oxd.server;
 
 import com.google.common.collect.Lists;
-import junit.framework.Assert;
 import org.testng.annotations.Test;
 import org.gluu.util.security.StringEncrypter;
-
+import static org.testng.AssertJUnit.assertEquals;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -20,7 +19,7 @@ public class UtilsTest {
     @Test
     public void joinAndEncode() throws UnsupportedEncodingException {
         final ArrayList<String> list = Lists.newArrayList("id_token", "token");
-        Assert.assertEquals("id_token%20token", Utils.joinAndUrlEncode(list));
+        assertEquals("id_token%20token", Utils.joinAndUrlEncode(list));
     }
 
     @Test(enabled = false)
@@ -36,7 +35,7 @@ public class UtilsTest {
 
         calendar.add(Calendar.HOUR, 13);
 
-        Assert.assertEquals(Utils.hoursDiff(today, calendar.getTime()), 13);
+        assertEquals(Utils.hoursDiff(today, calendar.getTime()), 13);
     }
 
     public static void main(String[] args) {

--- a/oxd-server/src/test/java/org/gluu/oxd/server/manual/NotAllowedTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/manual/NotAllowedTest.java
@@ -14,8 +14,8 @@ import org.gluu.oxd.server.Tester;
 
 import java.io.IOException;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Yuriy Zabrovarnyy

--- a/oxd-server/src/test/java/org/gluu/oxd/server/manual/StressTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/manual/StressTest.java
@@ -1,6 +1,5 @@
 package org.gluu.oxd.server.manual;
 
-import junit.framework.Assert;
 import org.gluu.oxd.client.ClientInterface;
 import org.gluu.oxd.common.params.GetAuthorizationUrlParams;
 import org.gluu.oxd.common.response.GetAuthorizationUrlResponse;
@@ -10,7 +9,8 @@ import org.gluu.oxd.server.Tester;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.gluu.oxd.server.TestUtils.notEmpty;
 
 /**
@@ -33,6 +33,6 @@ public class StressTest {
         final GetAuthorizationUrlResponse resp = client.getAuthorizationUrl(Tester.getAuthorization(), params);
         assertNotNull(resp);
         notEmpty(resp.getAuthorizationUrl());
-        Assert.assertTrue(resp.getAuthorizationUrl().contains("acr_values"));
+        assertTrue(resp.getAuthorizationUrl().contains("acr_values"));
     }
 }

--- a/oxd-server/src/test/java/org/gluu/oxd/server/manual/oxAuthDiscoveryTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/manual/oxAuthDiscoveryTest.java
@@ -3,11 +3,10 @@
  */
 package org.gluu.oxd.server.manual;
 
-import junit.framework.Assert;
 import org.testng.annotations.Test;
 import org.gluu.oxauth.client.OpenIdConfigurationClient;
 import org.gluu.oxauth.client.OpenIdConfigurationResponse;
-
+import static org.testng.AssertJUnit.assertNotNull;
 import java.io.IOException;
 
 /**
@@ -23,6 +22,6 @@ public class oxAuthDiscoveryTest {
         OpenIdConfigurationClient client = new OpenIdConfigurationClient(url);
         OpenIdConfigurationResponse response = client.execOpenIdConfiguration();
         System.out.println(response.getEntity());
-        Assert.assertNotNull(response);
+        assertNotNull(response);
     }
 }

--- a/oxd-server/src/test/java/org/gluu/oxd/server/service/RpServiceTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/service/RpServiceTest.java
@@ -17,8 +17,8 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * @author Yuriy Zabrovarnyy

--- a/oxd-server/src/test/java/org/gluu/oxd/server/service/StateServiceTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/service/StateServiceTest.java
@@ -2,10 +2,10 @@ package org.gluu.oxd.server.service;
 
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
-import junit.framework.Assert;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 import org.gluu.oxd.server.guice.GuiceModule;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Yuriy Zabrovarnyy
@@ -25,7 +25,7 @@ public class StateServiceTest {
     private String generateState() {
         String state = stateService.generateState();
         System.out.println(state);
-        Assert.assertTrue(!Strings.isNullOrEmpty(state));
+        assertTrue(!Strings.isNullOrEmpty(state));
         return state;
     }
 }

--- a/oxd-server/src/test/java/org/gluu/oxd/server/service/UmaTokenServiceTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/service/UmaTokenServiceTest.java
@@ -5,8 +5,8 @@ import org.gluu.oxd.common.CoreUtils;
 
 import java.util.Calendar;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Yuriy Zabrovarnyy


### PR DESCRIPTION
#396 - Upgrade `Dropwizard` dependency from version `1.3.1` to `2.0.0` in oxd
https://github.com/GluuFederation/oxd/issues/396