### PR TITLE
#409 - Add spontaneous scopes to oxd, Part 1

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/params/RegisterSiteParams.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/params/RegisterSiteParams.java
@@ -127,6 +127,10 @@ public class RegisterSiteParams implements HasOxdIdParams {
     private Boolean syncClientFromOp = false;
     @JsonProperty(value = "sync_client_period_in_seconds")
     private int syncClientPeriodInSeconds = 86400;
+    @JsonProperty(value = "allow_spontaneous_scopes")
+    private Boolean allowSpontaneousScopes = false;
+    @JsonProperty(value = "spontaneous_scopes")
+    private List<String> spontaneousScopes;
 
     public RegisterSiteParams() {
     }
@@ -855,6 +859,22 @@ public class RegisterSiteParams implements HasOxdIdParams {
         this.syncClientPeriodInSeconds = syncClientPeriodInSeconds;
     }
 
+    public Boolean getAllowSpontaneousScopes() {
+        return allowSpontaneousScopes;
+    }
+
+    public void setAllowSpontaneousScopes(Boolean allowSpontaneousScopes) {
+        this.allowSpontaneousScopes = allowSpontaneousScopes;
+    }
+
+    public List<String> getSpontaneousScopes() {
+        return spontaneousScopes;
+    }
+
+    public void setSpontaneousScopes(List<String> spontaneousScopes) {
+        this.spontaneousScopes = spontaneousScopes;
+    }
+
     @Override
     public String toString() {
         return "RegisterSiteParams{" +
@@ -913,6 +933,8 @@ public class RegisterSiteParams implements HasOxdIdParams {
                 ", custom_attributes='" + custom_attributes + '\'' +
                 ", syncClientFromOp='" + syncClientFromOp + '\'' +
                 ", syncClientPeriodInSeconds='" + syncClientPeriodInSeconds + '\'' +
+                ", allowSpontaneousScopes='" + allowSpontaneousScopes + '\'' +
+                ", spontaneousScopes='" + spontaneousScopes + '\'' +
                 '}';
     }
 

--- a/oxd-common/src/main/java/org/gluu/oxd/common/params/UpdateSiteParams.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/params/UpdateSiteParams.java
@@ -130,6 +130,10 @@ public class UpdateSiteParams implements HasAccessTokenParams {
     private Boolean syncClientFromOp = false;
     @JsonProperty(value = "sync_client_period_in_seconds")
     private int syncClientPeriodInSeconds = 86400;
+    @JsonProperty(value = "allow_spontaneous_scopes")
+    private Boolean allowSpontaneousScopes = false;
+    @JsonProperty(value = "spontaneous_scopes")
+    private List<String> spontaneousScopes;
 
     public UpdateSiteParams() {
     }
@@ -858,6 +862,22 @@ public class UpdateSiteParams implements HasAccessTokenParams {
         this.syncClientPeriodInSeconds = syncClientPeriodInSeconds;
     }
 
+    public Boolean getAllowSpontaneousScopes() {
+        return allowSpontaneousScopes;
+    }
+
+    public void setAllowSpontaneousScopes(Boolean allowSpontaneousScopes) {
+        this.allowSpontaneousScopes = allowSpontaneousScopes;
+    }
+
+    public List<String> getSpontaneousScopes() {
+        return spontaneousScopes;
+    }
+
+    public void setSpontaneousScopes(List<String> spontaneousScopes) {
+        this.spontaneousScopes = spontaneousScopes;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -917,6 +937,8 @@ public class UpdateSiteParams implements HasAccessTokenParams {
         sb.append(", custom_attributes=").append(custom_attributes);
         sb.append(", syncClientFromOp=").append(syncClientFromOp);
         sb.append(", syncClientPeriodInSeconds=").append(syncClientPeriodInSeconds);
+        sb.append(", allowSpontaneousScopes=").append(allowSpontaneousScopes);
+        sb.append(", spontaneousScopes=").append(spontaneousScopes);
         sb.append('}');
         return sb.toString();
     }

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/RegisterSiteParams.java
@@ -31,7 +31,7 @@ import java.util.Map;
 /**
  * RegisterSiteParams
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-01-21T06:12:36.096Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-01-22T13:33:32.189Z")
 public class RegisterSiteParams {
   @SerializedName("redirect_uris")
   private List<String> redirectUris = new ArrayList<String>();
@@ -188,6 +188,12 @@ public class RegisterSiteParams {
 
   @SerializedName("sync_client_period_in_seconds")
   private Integer syncClientPeriodInSeconds = null;
+
+  @SerializedName("allow_spontaneous_scopes")
+  private Boolean allowSpontaneousScopes = null;
+
+  @SerializedName("spontaneous_scopes")
+  private List<String> spontaneousScopes = null;
 
   public RegisterSiteParams redirectUris(List<String> redirectUris) {
     this.redirectUris = redirectUris;
@@ -1234,6 +1240,50 @@ public class RegisterSiteParams {
     this.syncClientPeriodInSeconds = syncClientPeriodInSeconds;
   }
 
+  public RegisterSiteParams allowSpontaneousScopes(Boolean allowSpontaneousScopes) {
+    this.allowSpontaneousScopes = allowSpontaneousScopes;
+    return this;
+  }
+
+   /**
+   * specifies whether to allow spontaneous scopes for client. The default value is false
+   * @return allowSpontaneousScopes
+  **/
+  @ApiModelProperty(example = "false", value = "specifies whether to allow spontaneous scopes for client. The default value is false")
+  public Boolean isAllowSpontaneousScopes() {
+    return allowSpontaneousScopes;
+  }
+
+  public void setAllowSpontaneousScopes(Boolean allowSpontaneousScopes) {
+    this.allowSpontaneousScopes = allowSpontaneousScopes;
+  }
+
+  public RegisterSiteParams spontaneousScopes(List<String> spontaneousScopes) {
+    this.spontaneousScopes = spontaneousScopes;
+    return this;
+  }
+
+  public RegisterSiteParams addSpontaneousScopesItem(String spontaneousScopesItem) {
+    if (this.spontaneousScopes == null) {
+      this.spontaneousScopes = new ArrayList<String>();
+    }
+    this.spontaneousScopes.add(spontaneousScopesItem);
+    return this;
+  }
+
+   /**
+   * list of spontaneous scopes (regexp against which validation is performed).
+   * @return spontaneousScopes
+  **/
+  @ApiModelProperty(value = "list of spontaneous scopes (regexp against which validation is performed).")
+  public List<String> getSpontaneousScopes() {
+    return spontaneousScopes;
+  }
+
+  public void setSpontaneousScopes(List<String> spontaneousScopes) {
+    this.spontaneousScopes = spontaneousScopes;
+  }
+
 
   @Override
   public boolean equals(Object o) {
@@ -1295,12 +1345,14 @@ public class RegisterSiteParams {
         Objects.equals(this.softwareStatement, registerSiteParams.softwareStatement) &&
         Objects.equals(this.customAttributes, registerSiteParams.customAttributes) &&
         Objects.equals(this.syncClientFromOp, registerSiteParams.syncClientFromOp) &&
-        Objects.equals(this.syncClientPeriodInSeconds, registerSiteParams.syncClientPeriodInSeconds);
+        Objects.equals(this.syncClientPeriodInSeconds, registerSiteParams.syncClientPeriodInSeconds) &&
+        Objects.equals(this.allowSpontaneousScopes, registerSiteParams.allowSpontaneousScopes) &&
+        Objects.equals(this.spontaneousScopes, registerSiteParams.spontaneousScopes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(redirectUris, opHost, postLogoutRedirectUris, responseTypes, grantTypes, scope, acrValues, clientName, clientJwksUri, clientTokenEndpointAuthMethod, clientTokenEndpointAuthSigningAlg, clientRequestUris, clientFrontchannelLogoutUris, clientSectorIdentifierUri, contacts, uiLocales, claimsLocales, claimsRedirectUri, clientId, clientSecret, accessTokenAsJwt, accessTokenSigningAlg, rptAsJwt, logoUri, clientUri, policyUri, frontChannelLogoutSessionRequired, tosUri, jwks, idTokenBindingCnf, tlsClientAuthSubjectDn, runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims, idTokenSignedResponseAlg, idTokenEncryptedResponseAlg, idTokenEncryptedResponseEnc, userInfoSignedResponseAlg, userInfoEncryptedResponseAlg, userInfoEncryptedResponseEnc, requestObjectSigningAlg, requestObjectEncryptionAlg, requestObjectEncryptionEnc, defaultMaxAge, requireAuthTime, initiateLoginUri, authorizedOrigins, accessTokenLifetime, softwareId, softwareVersion, softwareStatement, customAttributes, syncClientFromOp, syncClientPeriodInSeconds);
+    return Objects.hash(redirectUris, opHost, postLogoutRedirectUris, responseTypes, grantTypes, scope, acrValues, clientName, clientJwksUri, clientTokenEndpointAuthMethod, clientTokenEndpointAuthSigningAlg, clientRequestUris, clientFrontchannelLogoutUris, clientSectorIdentifierUri, contacts, uiLocales, claimsLocales, claimsRedirectUri, clientId, clientSecret, accessTokenAsJwt, accessTokenSigningAlg, rptAsJwt, logoUri, clientUri, policyUri, frontChannelLogoutSessionRequired, tosUri, jwks, idTokenBindingCnf, tlsClientAuthSubjectDn, runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims, idTokenSignedResponseAlg, idTokenEncryptedResponseAlg, idTokenEncryptedResponseEnc, userInfoSignedResponseAlg, userInfoEncryptedResponseAlg, userInfoEncryptedResponseEnc, requestObjectSigningAlg, requestObjectEncryptionAlg, requestObjectEncryptionEnc, defaultMaxAge, requireAuthTime, initiateLoginUri, authorizedOrigins, accessTokenLifetime, softwareId, softwareVersion, softwareStatement, customAttributes, syncClientFromOp, syncClientPeriodInSeconds, allowSpontaneousScopes, spontaneousScopes);
   }
 
 
@@ -1361,6 +1413,8 @@ public class RegisterSiteParams {
     sb.append("    customAttributes: ").append(toIndentedString(customAttributes)).append("\n");
     sb.append("    syncClientFromOp: ").append(toIndentedString(syncClientFromOp)).append("\n");
     sb.append("    syncClientPeriodInSeconds: ").append(toIndentedString(syncClientPeriodInSeconds)).append("\n");
+    sb.append("    allowSpontaneousScopes: ").append(toIndentedString(allowSpontaneousScopes)).append("\n");
+    sb.append("    spontaneousScopes: ").append(toIndentedString(spontaneousScopes)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/UpdateSiteParams.java
@@ -31,7 +31,7 @@ import java.util.Map;
 /**
  * UpdateSiteParams
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-01-21T06:12:36.096Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-01-22T13:33:32.189Z")
 public class UpdateSiteParams {
   @SerializedName("oxd_id")
   private String oxdId = null;
@@ -179,6 +179,12 @@ public class UpdateSiteParams {
 
   @SerializedName("sync_client_period_in_seconds")
   private Integer syncClientPeriodInSeconds = null;
+
+  @SerializedName("allow_spontaneous_scopes")
+  private Boolean allowSpontaneousScopes = null;
+
+  @SerializedName("spontaneous_scopes")
+  private List<String> spontaneousScopes = null;
 
   public UpdateSiteParams oxdId(String oxdId) {
     this.oxdId = oxdId;
@@ -1166,6 +1172,50 @@ public class UpdateSiteParams {
     this.syncClientPeriodInSeconds = syncClientPeriodInSeconds;
   }
 
+  public UpdateSiteParams allowSpontaneousScopes(Boolean allowSpontaneousScopes) {
+    this.allowSpontaneousScopes = allowSpontaneousScopes;
+    return this;
+  }
+
+   /**
+   * specifies whether to allow spontaneous scopes for client. The default value is false
+   * @return allowSpontaneousScopes
+  **/
+  @ApiModelProperty(example = "false", value = "specifies whether to allow spontaneous scopes for client. The default value is false")
+  public Boolean isAllowSpontaneousScopes() {
+    return allowSpontaneousScopes;
+  }
+
+  public void setAllowSpontaneousScopes(Boolean allowSpontaneousScopes) {
+    this.allowSpontaneousScopes = allowSpontaneousScopes;
+  }
+
+  public UpdateSiteParams spontaneousScopes(List<String> spontaneousScopes) {
+    this.spontaneousScopes = spontaneousScopes;
+    return this;
+  }
+
+  public UpdateSiteParams addSpontaneousScopesItem(String spontaneousScopesItem) {
+    if (this.spontaneousScopes == null) {
+      this.spontaneousScopes = new ArrayList<String>();
+    }
+    this.spontaneousScopes.add(spontaneousScopesItem);
+    return this;
+  }
+
+   /**
+   * list of spontaneous scopes (regexp against which validation is performed).
+   * @return spontaneousScopes
+  **/
+  @ApiModelProperty(value = "list of spontaneous scopes (regexp against which validation is performed).")
+  public List<String> getSpontaneousScopes() {
+    return spontaneousScopes;
+  }
+
+  public void setSpontaneousScopes(List<String> spontaneousScopes) {
+    this.spontaneousScopes = spontaneousScopes;
+  }
+
 
   @Override
   public boolean equals(Object o) {
@@ -1224,12 +1274,14 @@ public class UpdateSiteParams {
         Objects.equals(this.softwareStatement, updateSiteParams.softwareStatement) &&
         Objects.equals(this.customAttributes, updateSiteParams.customAttributes) &&
         Objects.equals(this.syncClientFromOp, updateSiteParams.syncClientFromOp) &&
-        Objects.equals(this.syncClientPeriodInSeconds, updateSiteParams.syncClientPeriodInSeconds);
+        Objects.equals(this.syncClientPeriodInSeconds, updateSiteParams.syncClientPeriodInSeconds) &&
+        Objects.equals(this.allowSpontaneousScopes, updateSiteParams.allowSpontaneousScopes) &&
+        Objects.equals(this.spontaneousScopes, updateSiteParams.spontaneousScopes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(oxdId, redirectUris, postLogoutRedirectUris, responseTypes, grantTypes, scope, acrValues, clientJwksUri, clientTokenEndpointAuthMethod, clientRequestUris, clientSectorIdentifierUri, contacts, uiLocales, claimsLocales, accessTokenAsJwt, accessTokenSigningAlg, rptAsJwt, claimsRedirectUri, clientTokenEndpointAuthSigningAlg, clientName, logoUri, clientUri, policyUri, frontChannelLogoutSessionRequired, tosUri, jwks, idTokenBindingCnf, tlsClientAuthSubjectDn, runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims, idTokenSignedResponseAlg, idTokenEncryptedResponseAlg, idTokenEncryptedResponseEnc, userInfoSignedResponseAlg, userInfoEncryptedResponseAlg, userInfoEncryptedResponseEnc, requestObjectSigningAlg, requestObjectEncryptionAlg, requestObjectEncryptionEnc, defaultMaxAge, requireAuthTime, initiateLoginUri, authorizedOrigins, accessTokenLifetime, softwareId, softwareVersion, softwareStatement, customAttributes, syncClientFromOp, syncClientPeriodInSeconds);
+    return Objects.hash(oxdId, redirectUris, postLogoutRedirectUris, responseTypes, grantTypes, scope, acrValues, clientJwksUri, clientTokenEndpointAuthMethod, clientRequestUris, clientSectorIdentifierUri, contacts, uiLocales, claimsLocales, accessTokenAsJwt, accessTokenSigningAlg, rptAsJwt, claimsRedirectUri, clientTokenEndpointAuthSigningAlg, clientName, logoUri, clientUri, policyUri, frontChannelLogoutSessionRequired, tosUri, jwks, idTokenBindingCnf, tlsClientAuthSubjectDn, runIntrospectionScriptBeforeaccessTokenAsJwtCreationAndIncludeClaims, idTokenSignedResponseAlg, idTokenEncryptedResponseAlg, idTokenEncryptedResponseEnc, userInfoSignedResponseAlg, userInfoEncryptedResponseAlg, userInfoEncryptedResponseEnc, requestObjectSigningAlg, requestObjectEncryptionAlg, requestObjectEncryptionEnc, defaultMaxAge, requireAuthTime, initiateLoginUri, authorizedOrigins, accessTokenLifetime, softwareId, softwareVersion, softwareStatement, customAttributes, syncClientFromOp, syncClientPeriodInSeconds, allowSpontaneousScopes, spontaneousScopes);
   }
 
 
@@ -1287,6 +1339,8 @@ public class UpdateSiteParams {
     sb.append("    customAttributes: ").append(toIndentedString(customAttributes)).append("\n");
     sb.append("    syncClientFromOp: ").append(toIndentedString(syncClientFromOp)).append("\n");
     sb.append("    syncClientPeriodInSeconds: ").append(toIndentedString(syncClientPeriodInSeconds)).append("\n");
+    sb.append("    allowSpontaneousScopes: ").append(toIndentedString(allowSpontaneousScopes)).append("\n");
+    sb.append("    spontaneousScopes: ").append(toIndentedString(spontaneousScopes)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/mapper/RegisterRequestMapper.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/mapper/RegisterRequestMapper.java
@@ -153,6 +153,14 @@ public class RegisterRequestMapper {
         if (CollectionUtils.isNotEmpty(request.getClaimsRedirectUris())) {
             rp.setClaimsRedirectUri(request.getClaimsRedirectUris());
         }
+
+        if (request.getAllowSpontaneousScopes() != null) {
+            rp.setAllowSpontaneousScopes(request.getAllowSpontaneousScopes());
+        }
+
+        if (CollectionUtils.isNotEmpty(request.getSpontaneousScopes())) {
+            rp.setSpontaneousScopes(request.getSpontaneousScopes());
+        }
     }
 
     public static RegisterRequest createRegisterRequest(Rp rp) {
@@ -293,6 +301,14 @@ public class RegisterRequestMapper {
 
         if (CollectionUtils.isNotEmpty(rp.getClaimsRedirectUri())) {
             request.setClaimsRedirectUris(rp.getClaimsRedirectUri());
+        }
+
+        if (rp.getAllowSpontaneousScopes() != null) {
+            request.setAllowSpontaneousScopes(rp.getAllowSpontaneousScopes());
+        }
+
+        if (CollectionUtils.isNotEmpty(rp.getSpontaneousScopes())) {
+            request.setSpontaneousScopes(rp.getSpontaneousScopes());
         }
 
         return request;

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
@@ -5,6 +5,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Injector;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.gluu.oxauth.client.RegisterClient;
@@ -698,6 +699,14 @@ public class RegisterSiteOperation extends BaseOperation<RegisterSiteParams> {
 
         if (!Strings.isNullOrEmpty(params.getSoftwareStatement())) {
             request.setSoftwareStatement(params.getSoftwareStatement());
+        }
+
+        if (params.getAllowSpontaneousScopes() != null) {
+            request.setAllowSpontaneousScopes(params.getAllowSpontaneousScopes());
+        }
+
+        if (CollectionUtils.isNotEmpty(params.getSpontaneousScopes())) {
+            request.setSpontaneousScopes(params.getSpontaneousScopes());
         }
 
         if (params.getCustomAttributes() != null && !params.getCustomAttributes().isEmpty()) {

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/UpdateSiteOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/UpdateSiteOperation.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Injector;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.gluu.oxauth.client.RegisterClient;
@@ -351,6 +352,14 @@ public class UpdateSiteOperation extends BaseOperation<UpdateSiteParams> {
 
         if (!Strings.isNullOrEmpty(params.getSoftwareStatement())) {
             request.setSoftwareStatement(params.getSoftwareStatement());
+        }
+
+        if (params.getAllowSpontaneousScopes() != null) {
+            request.setAllowSpontaneousScopes(params.getAllowSpontaneousScopes());
+        }
+
+        if (CollectionUtils.isNotEmpty(params.getSpontaneousScopes())) {
+            request.setSpontaneousScopes(params.getSpontaneousScopes());
         }
 
         if (params.getCustomAttributes() != null && !params.getCustomAttributes().isEmpty()) {

--- a/oxd-server/src/main/java/org/gluu/oxd/server/service/Rp.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/service/Rp.java
@@ -185,6 +185,10 @@ public class Rp implements Serializable {
     private Boolean syncClientFromOp;
     @JsonProperty(value = "sync_client_period_in_seconds")
     private Integer syncClientPeriodInSeconds;
+    @JsonProperty(value = "allow_spontaneous_scopes")
+    private Boolean allowSpontaneousScopes = false;
+    @JsonProperty(value = "spontaneous_scopes")
+    private List<String> spontaneousScopes;
 
     public Rp() {
     }
@@ -285,6 +289,8 @@ public class Rp implements Serializable {
         this.lastSynced = lastSynced;
         this.syncClientFromOp = syncClientFromOp;
         this.syncClientPeriodInSeconds = syncClientPeriodInSeconds;
+        this.allowSpontaneousScopes = allowSpontaneousScopes;
+        this.spontaneousScopes = spontaneousScopes;
     }
 
     public Boolean getAccessTokenAsJwt() {
@@ -1014,6 +1020,22 @@ public class Rp implements Serializable {
         this.syncClientPeriodInSeconds = syncClientPeriodInSeconds;
     }
 
+    public Boolean getAllowSpontaneousScopes() {
+        return allowSpontaneousScopes;
+    }
+
+    public void setAllowSpontaneousScopes(Boolean allowSpontaneousScopes) {
+        this.allowSpontaneousScopes = allowSpontaneousScopes;
+    }
+
+    public List<String> getSpontaneousScopes() {
+        return spontaneousScopes;
+    }
+
+    public void setSpontaneousScopes(List<String> spontaneousScopes) {
+        this.spontaneousScopes = spontaneousScopes;
+    }
+
     @Override
     public String toString() {
         return "Rp{" +
@@ -1098,6 +1120,8 @@ public class Rp implements Serializable {
                 ", lastSynced='" + lastSynced + '\'' +
                 ", syncClientFromOp='" + syncClientFromOp + '\'' +
                 ", syncClientPeriodInSeconds='" + syncClientPeriodInSeconds + '\'' +
+                ", allowSpontaneousScopes='" + allowSpontaneousScopes + '\'' +
+                ", spontaneousScopes='" + spontaneousScopes + '\'' +
                 '}';
     }
 }

--- a/oxd-server/src/main/resources/swagger.yaml
+++ b/oxd-server/src/main/resources/swagger.yaml
@@ -262,6 +262,16 @@ paths:
                 type: integer
                 description: specifies period after which client can sync again with OP. Default value is 86400 (in seconds).
                 example: 86400
+              allow_spontaneous_scopes:
+                type: boolean
+                description: specifies whether to allow spontaneous scopes for client. The default value is false
+                example: false
+              spontaneous_scopes:
+                type: array
+                description: list of spontaneous scopes (regexp against which validation is performed).
+                items:
+                  type: string
+                  example: ["/user/?/??", "/user/123abc/balance/history"]
 
       responses:
         200:
@@ -717,6 +727,16 @@ paths:
                 type: integer
                 description: specifies period after which client can sync again with OP. Default value is 86400 (in seconds).
                 example: 86400
+              allow_spontaneous_scopes:
+                type: boolean
+                description: specifies whether to allow spontaneous scopes for client. The default value is false
+                example: false
+              spontaneous_scopes:
+                type: array
+                description: list of spontaneous scopes (regexp against which validation is performed).
+                items:
+                  type: string
+                  example: ["/user/?/??", "/user/123abc/balance/history"]
 
       responses:
         200:


### PR DESCRIPTION
#409 - Add spontaneous scopes to oxd
https://github.com/GluuFederation/oxd/issues/409

In this PR we have added below params to `/register-site` and `/update-site`
----------------------------

allow_spontaneous_scopes - boolean, whether to allow spontaneous scopes for client
spontaneous_scopes - list of spontaneous scopes (regexp against which validation is performed)