### PR TITLE
#417 - Correcting licence document link in source code (`branch: version_4.1`)

### DIFF
--- a/oxd-gen-client/pom.xml
+++ b/oxd-gen-client/pom.xml
@@ -26,7 +26,7 @@
     <licenses>
         <license>
             <name>Unlicense</name>
-            <url>https://github.com/GluuFederation/oxd/blob/master/LICENSE</url>
+            <url> https://github.com/GluuFederation/oxd/blob/master/license.md</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/oxd-gen-client/pom.xml
+++ b/oxd-gen-client/pom.xml
@@ -26,7 +26,7 @@
     <licenses>
         <license>
             <name>Unlicense</name>
-            <url> https://github.com/GluuFederation/oxd/blob/master/license.md</url>
+            <url>https://github.com/GluuFederation/oxd/blob/master/license.md</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/oxd-server/src/main/resources/swagger.yaml
+++ b/oxd-server/src/main/resources/swagger.yaml
@@ -11,7 +11,7 @@ info:
 
   license:
     name: License
-    url: https://github.com/GluuFederation/oxd/blob/master/LICENSE
+    url: https://github.com/GluuFederation/oxd/blob/master/license.md
 
 host: gluu.org
 basePath: /


### PR DESCRIPTION
#417 - Correcting licence document link in source code (`branch: version_4.1`)
https://github.com/GluuFederation/oxd/issues/417