### PR TITLE
#442 - If kid is absent in ID_TOKEN header then the matching key out …

### DIFF
--- a/oxd-server/src/main/java/org/gluu/oxd/server/service/PublicOpKeyService.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/service/PublicOpKeyService.java
@@ -58,7 +58,7 @@ public class PublicOpKeyService {
                 return cachedKey;
             }
 
-            JwkClient jwkClient = new JwkClient(jwkSetUrl);
+            JwkClient jwkClient = opClientFactory.createJwkClient(jwkSetUrl);
             jwkClient.setExecutor(new ApacheHttpClient4Executor(httpService.getHttpClient()));
 
             JwkResponse jwkResponse = jwkClient.exec();


### PR DESCRIPTION
#442 - If kid is absent in ID_TOKEN header then the matching key out of the Issuer's published set 
https://github.com/GluuFederation/oxd/issues/442