### PR TITLE
#438 - If 'iat' value is missing from `ID_TOKEN` then `ID_TOKEN` should be rejected during token validation.

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
@@ -90,7 +90,8 @@ public enum ErrorResponseCode {
     INVALID_ALGORITHM(500, "invalid_algorithm", "Invalid algorithm provided (empty or null)."),
     ALGORITHM_NOT_SUPPORTED(500, "algorithm_not_supported", "Algorithm not supported."),
     KEY_ID_NOT_FOUND(500, "key_id_not_found", "`kid` is missing in `ID_TOKEN`. Unable to find matching key out of the Issuer's published set."),
-    NO_SUBJECT_IDENTIFIER(500, "no_subject_identifier", "ID Token is missing `sub` value.");
+    NO_SUBJECT_IDENTIFIER(500, "no_subject_identifier", "ID Token is missing `sub` value."),
+    INVALID_ID_TOKEN_ISSUED_AT(500, "invalid_id_token_issued_at", "`ISSUED_AT` date is either invalid or missing from `ID_TOKEN`.");
 
     private final int httpStatus;
     private final String code;

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/Validator.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/Validator.java
@@ -204,8 +204,15 @@ public class Validator {
 
             //validate subject identifier
             if (Strings.isNullOrEmpty(sub)) {
-               LOG.error("ID Token is missing `sub` value.");
+                LOG.error("ID Token is missing `sub` value.");
                 throw new HttpException(ErrorResponseCode.NO_SUBJECT_IDENTIFIER);
+            }
+
+            //validate id_token issued at date
+            final Date issuedAt = idToken.getClaims().getClaimAsDate(JwtClaimName.ISSUED_AT);
+            if (issuedAt == null) {
+                LOG.error("`ISSUED_AT` date is either invalid or missing from `ID_TOKEN`.");
+                throw new HttpException(ErrorResponseCode.INVALID_ID_TOKEN_ISSUED_AT);
             }
 
             //validate id_token expire date


### PR DESCRIPTION
#438 - If 'iat' value is missing from `ID_TOKEN` then `ID_TOKEN` should be rejected during token validation.

https://github.com/GluuFederation/oxd/issues/438