### PR TITLE
#441 - Identify the invalid 'sub' value and reject the UserInfo Response

### DIFF
--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/GetUserInfoOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/GetUserInfoOperation.java
@@ -46,10 +46,11 @@ public class GetUserInfoOperation extends BaseOperation<GetUserInfoParams> {
         client.setRequest(new UserInfoRequest(params.getAccessToken()));
 
         final UserInfoResponse response = client.exec();
-
-        final Rp rp = getRp();
-        validateSubjectIdentifier(rp.getIdToken(), response);
-
+        //validate subject identifier of successful response
+        if (response.getStatus() == 200) {
+            final Rp rp = getRp();
+            validateSubjectIdentifier(rp.getIdToken(), response);
+        }
 
         return new POJOResponse(Jackson2.createJsonMapper().readTree(response.getEntity()));
     }


### PR DESCRIPTION
#441 - Identify the invalid 'sub' value and reject the UserInfo Response
https://github.com/GluuFederation/oxd/issues/441

Correcting the test case by validating the subject_identifier of an only successful response.