### PR TITLE
#449 - Adding `nonce` request parameter to explicitly pass `nonce` value to Authentication Request.

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/params/GetAuthorizationUrlParams.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/params/GetAuthorizationUrlParams.java
@@ -28,6 +28,8 @@ public class GetAuthorizationUrlParams implements HasAccessTokenParams {
     private String token;
     @JsonProperty(value = "state")
     private String state;
+    @JsonProperty(value = "nonce")
+    private String nonce;
     @JsonProperty(value = "custom_parameters")
     private Map<String, String> custom_parameters;
     @JsonProperty(value = "params")
@@ -128,6 +130,14 @@ public class GetAuthorizationUrlParams implements HasAccessTokenParams {
         this.response_types = responseTypes;
     }
 
+    public String getNonce() {
+        return nonce;
+    }
+
+    public void setNonce(String nonce) {
+        this.nonce = nonce;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -159,6 +169,7 @@ public class GetAuthorizationUrlParams implements HasAccessTokenParams {
                 ", custom_parameters=" + custom_parameters +
                 ", redirect_uri='" + redirect_uri + '\'' +
                 ", state='" + state + '\'' +
+                ", nonce='" + nonce + '\'' +
                 ", response_types=" + response_types + '\'' +
                 '}';
     }

--- a/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlParams.java
+++ b/oxd-gen-client/src/main/java/io/swagger/client/model/GetAuthorizationUrlParams.java
@@ -46,6 +46,9 @@ public class GetAuthorizationUrlParams {
   @SerializedName("state")
   private String state = null;
 
+  @SerializedName("nonce")
+  private String nonce = null;
+
   @SerializedName("redirect_uri")
   private String redirectUri = null;
 
@@ -164,6 +167,24 @@ public class GetAuthorizationUrlParams {
     this.state = state;
   }
 
+  public GetAuthorizationUrlParams nonce(String nonce) {
+    this.nonce = nonce;
+    return this;
+  }
+
+   /**
+   * Get nonce
+   * @return nonce
+  **/
+  @Schema(description = "")
+  public String getNonce() {
+    return nonce;
+  }
+
+  public void setNonce(String nonce) {
+    this.nonce = nonce;
+  }
+
   public GetAuthorizationUrlParams redirectUri(String redirectUri) {
     this.redirectUri = redirectUri;
     return this;
@@ -275,6 +296,7 @@ public class GetAuthorizationUrlParams {
         Objects.equals(this.acrValues, getAuthorizationUrlParams.acrValues) &&
         Objects.equals(this.prompt, getAuthorizationUrlParams.prompt) &&
         Objects.equals(this.state, getAuthorizationUrlParams.state) &&
+        Objects.equals(this.nonce, getAuthorizationUrlParams.nonce) &&
         Objects.equals(this.redirectUri, getAuthorizationUrlParams.redirectUri) &&
         Objects.equals(this.responseTypes, getAuthorizationUrlParams.responseTypes) &&
         Objects.equals(this.customParameters, getAuthorizationUrlParams.customParameters) &&
@@ -283,7 +305,7 @@ public class GetAuthorizationUrlParams {
 
   @Override
   public int hashCode() {
-    return Objects.hash(oxdId, scope, acrValues, prompt, state, redirectUri, responseTypes, customParameters, params);
+    return Objects.hash(oxdId, scope, acrValues, prompt, state, nonce, redirectUri, responseTypes, customParameters, params);
   }
 
 
@@ -297,6 +319,7 @@ public class GetAuthorizationUrlParams {
     sb.append("    acrValues: ").append(toIndentedString(acrValues)).append("\n");
     sb.append("    prompt: ").append(toIndentedString(prompt)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
+    sb.append("    nonce: ").append(toIndentedString(nonce)).append("\n");
     sb.append("    redirectUri: ").append(toIndentedString(redirectUri)).append("\n");
     sb.append("    responseTypes: ").append(toIndentedString(responseTypes)).append("\n");
     sb.append("    customParameters: ").append(toIndentedString(customParameters)).append("\n");

--- a/oxd-gen-client/src/test/java/io/swagger/client/api/GetAuthorizationUrlTest.java
+++ b/oxd-gen-client/src/test/java/io/swagger/client/api/GetAuthorizationUrlTest.java
@@ -51,6 +51,25 @@ public class GetAuthorizationUrlTest {
 
     @Parameters({"redirectUrls", "opHost"})
     @Test
+    public void testWithNonceParameter(String redirectUrls, String opHost) throws Exception {
+        DevelopersApi api = Tester.api();
+
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(api, opHost, redirectUrls);
+        final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
+        commandParams.setOxdId(site.getOxdId());
+        commandParams.setNonce("dummy_nonce");
+
+        final GetAuthorizationUrlResponse resp = api.getAuthorizationUrl(commandParams, Tester.getAuthorization(site));
+        assertNotNull(resp);
+        Tester.notEmpty(resp.getAuthorizationUrl());
+
+        Map<String, String> parameters = CoreUtils.splitQuery(resp.getAuthorizationUrl());
+        assertTrue(StringUtils.isNotBlank(parameters.get("nonce")));
+        assertEquals(parameters.get("nonce"), "dummy_nonce");
+    }
+
+    @Parameters({"redirectUrls", "opHost"})
+    @Test
     public void testWithResposeType(String redirectUrls, String opHost) throws Exception {
         DevelopersApi api = Tester.api();
 

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/CheckIdTokenOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/CheckIdTokenOperation.java
@@ -56,7 +56,7 @@ public class CheckIdTokenOperation extends BaseOperation<CheckIdTokenParams> {
             validator.validateAuthorizationCode(params.getCode());
 
             final CheckIdTokenResponse opResponse = new CheckIdTokenResponse();
-            opResponse.setActive(validator.isIdTokenValid());
+            opResponse.setActive(validator.isIdTokenValid(params.getNonce()));
             opResponse.setIssuedAt(Utils.date(jwt.getClaims().getClaimAsDate(JwtClaimName.ISSUED_AT)));
             opResponse.setExpiresAt(Utils.date(jwt.getClaims().getClaimAsDate(JwtClaimName.EXPIRATION_TIME)));
             opResponse.setClaims(jwt.getClaims().toMap());

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/GetAuthorizationUrlOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/GetAuthorizationUrlOperation.java
@@ -68,6 +68,7 @@ public class GetAuthorizationUrlOperation extends BaseOperation<GetAuthorization
         }
 
         String state = StringUtils.isNotBlank(params.getState()) ? getStateService().putState(Utils.encode(params.getState())) : getStateService().generateState();
+        String nonce = StringUtils.isNotBlank(params.getNonce()) ? getStateService().putNonce(Utils.encode(params.getNonce())) : getStateService().generateNonce();
         String redirectUri = StringUtils.isNotBlank(params.getRedirectUri()) ? params.getRedirectUri() : rp.getRedirectUri();
 
         authorizationEndpoint += "?response_type=" + Utils.joinAndUrlEncode(responseTypes);
@@ -75,7 +76,7 @@ public class GetAuthorizationUrlOperation extends BaseOperation<GetAuthorization
         authorizationEndpoint += "&redirect_uri=" + redirectUri;
         authorizationEndpoint += "&scope=" + Utils.joinAndUrlEncode(scope);
         authorizationEndpoint += "&state=" + state;
-        authorizationEndpoint += "&nonce=" + getStateService().generateNonce();
+        authorizationEndpoint += "&nonce=" + nonce;
 
         String acrValues = Utils.joinAndUrlEncode(acrValues(rp, params)).trim();
         if (!Strings.isNullOrEmpty(acrValues)) {

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/Validator.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/Validator.java
@@ -234,9 +234,9 @@ public class Validator {
         }
     }
 
-    public boolean isIdTokenValid() {
+    public boolean isIdTokenValid(String nonce) {
         try {
-            validateIdToken();
+            validateIdToken(nonce);
             return true;
         } catch (Exception e) {
             return false;

--- a/oxd-server/src/main/resources/swagger.yaml
+++ b/oxd-server/src/main/resources/swagger.yaml
@@ -1094,6 +1094,8 @@ paths:
                   type: string
                 state:
                   type: string
+                nonce:
+                  type: string
                 redirect_uri:
                   type: string
                   example: https://client.example.org/cb

--- a/oxd-server/src/test/java/org/gluu/oxd/server/GetAuthorizationUrlTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/GetAuthorizationUrlTest.java
@@ -122,4 +122,25 @@ public class GetAuthorizationUrlTest {
         assertTrue(StringUtils.isNotBlank(parameters.get("state")));
         assertEquals(parameters.get("state"), state);
     }
+
+    @Parameters({"host", "opHost", "redirectUrls", "postLogoutRedirectUrl", "logoutUrl", "paramRedirectUrl"})
+    @Test
+    public void testWithNonceParameter(String host, String opHost, String redirectUrls, String postLogoutRedirectUrl, String logoutUrl, String paramRedirectUrl) throws IOException {
+        ClientInterface client = Tester.newClient(host);
+
+        final RegisterSiteResponse site = RegisterSiteTest.registerSite(client, opHost, redirectUrls, postLogoutRedirectUrl, logoutUrl, false);
+        final GetAuthorizationUrlParams commandParams = new GetAuthorizationUrlParams();
+        commandParams.setOxdId(site.getOxdId());
+        commandParams.setRedirectUri(paramRedirectUrl);
+        commandParams.setNonce("dummy_nonce");
+
+        final GetAuthorizationUrlResponse resp = client.getAuthorizationUrl(Tester.getAuthorization(), commandParams);
+        assertNotNull(resp);
+        notEmpty(resp.getAuthorizationUrl());
+        assertTrue(resp.getAuthorizationUrl().contains(paramRedirectUrl));
+
+        Map<String, String> parameters = CoreUtils.splitQuery(resp.getAuthorizationUrl());
+        assertTrue(StringUtils.isNotBlank(parameters.get("nonce")));
+        assertEquals(parameters.get("nonce"), "dummy_nonce");
+    }
 }


### PR DESCRIPTION
#449 - Adding `nonce` request parameter to explicitly pass `nonce` value to Authentication Request.

https://github.com/GluuFederation/oxd/issues/449