### PR TITLE
#466 - Support different AS for `access_token` validation (other then the one processing API call)

### DIFF
--- a/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
+++ b/oxd-server/src/test/java/org/gluu/oxd/server/RegisterSiteTest.java
@@ -194,7 +194,7 @@ public class RegisterSiteTest {
         final RegisterSiteParams params = new RegisterSiteParams();
         params.setOpHost(opHost);
         params.setRedirectUris(Lists.newArrayList(redirectUrls.split(" ")));
-        params.setScope(Lists.newArrayList("openid", "uma_protection", "profile"));
+        params.setScope(Lists.newArrayList("openid", "uma_protection", "profile", "oxd"));
         params.setResponseTypes(Lists.newArrayList("code", "id_token", "token"));
         params.setIdTokenSignedResponseAlg(idTokenSignedResponseAlg);
         params.setGrantTypes(Lists.newArrayList(


### PR DESCRIPTION
#466 - Support different AS for `access_token` validation (other then the one processing API call)
https://github.com/GluuFederation/oxd/issues/466