### PR TITLE
#471 - Set default `sync_client_from_op` and `sync_client_period_in_econds` when clients created using oxd version <= 4.1 and used in version4.2

### DIFF
--- a/oxd-server/src/main/java/org/gluu/oxd/server/service/Rp.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/service/Rp.java
@@ -184,9 +184,9 @@ public class Rp implements Serializable {
     @JsonProperty(value = "last_synced")
     private Date lastSynced;
     @JsonProperty(value = "sync_client_from_op")
-    private Boolean syncClientFromOp;
+    private Boolean syncClientFromOp = false;
     @JsonProperty(value = "sync_client_period_in_seconds")
-    private Integer syncClientPeriodInSeconds;
+    private Integer syncClientPeriodInSeconds = 3600;
     @JsonProperty(value = "allow_spontaneous_scopes")
     private Boolean allowSpontaneousScopes = false;
     @JsonProperty(value = "spontaneous_scopes")


### PR DESCRIPTION
#471 - Set default `sync_client_from_op` and `sync_client_period_in_econds` when RP for clients created using oxd version <= 4.1
https://github.com/GluuFederation/oxd/issues/471