### PR TITLE
Revert Bump htmlunit from 2.35.0 to 2.37.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
             <dependency>
                 <groupId>net.sourceforge.htmlunit</groupId>
                 <artifactId>htmlunit</artifactId>
-                <version>2.37.0</version>
+                <version>2.35.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Revert Bump htmlunit from 2.35.0 to 2.37.0 (as done in oxauth)