### PR TITLE
#510 - Save `client_id` and `client_secret` in oxd storage (in Rp table) when it is passed as paramater during client registration.

### DIFF
--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
@@ -442,6 +442,9 @@ public class RegisterSiteOperation extends BaseOperation<RegisterSiteParams> {
                 rp.setClientRegistrationClientUri(registerResponse.getRegistrationClientUri());
                 rp.setClientIdIssuedAt(registerResponse.getClientIdIssuedAt());
                 rp.setClientSecretExpiresAt(registerResponse.getClientSecretExpiresAt());
+            } else {
+                rp.setClientId(params.getClientId());
+                rp.setClientSecret(params.getClientSecret());
             }
 
             getRpService().create(rp);


### PR DESCRIPTION
#510 - Save `client_id` and `client_secret` in oxd storage (in Rp table) when it is passed as paramater during client registration.
https://github.com/GluuFederation/oxd/issues/510