### PR TITLE
#526 - Minor: Show clear error message when get `redirect_uri` with fragment component during registration instead of generic `invalid_redirect_uri`

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
@@ -60,7 +60,7 @@ public enum ErrorResponseCode {
     NO_CLIENT_ID_IN_INTROSPECTION_RESPONSE(500, "invalid_introspection_response", "AS returned introspection response with empty/blank client_id which is required by oxd. Please check your AS installation and make sure AS return client_id for introspection call (CE 3.1.0 or later)."),
     INACTIVE_ACCESS_TOKEN(403, "inactive_access_token", "Inactive access_token. Command is protected by access_token, please provide valid token or otherwise switch off protection in configuration with protect_commands_with_access_token=false"),
     INVALID_REDIRECT_URI(400, "invalid_redirect_uri", "Invalid redirect_uri (empty, blank or invalid)."),
-    URI_HAS_FRAGMENT_COMPONENT(400, "uri_has_fragment_component", "Fragment component is not allowed in redirect uri."),
+    REDIRECT_URI_HAS_FRAGMENT_COMPONENT(400, "redirect_uri_has_fragment_component", "Fragment component is not allowed in redirect uri."),
     INVALID_SCOPE(400, "invalid_scope", "Invalid scope parameter (empty or blank)."),
     INVALID_ACR_VALUES(400, "invalid_acr_values", "Invalid acr_values parameter (empty or blank)."),
     INVALID_SIGNATURE_ALGORITHM(400, "invalid_algorithm", "Invalid algorithm provided. Valid algorithms are: " + Arrays.toString(SignatureAlgorithm.values())),

--- a/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
@@ -60,6 +60,7 @@ public enum ErrorResponseCode {
     NO_CLIENT_ID_IN_INTROSPECTION_RESPONSE(500, "invalid_introspection_response", "AS returned introspection response with empty/blank client_id which is required by oxd. Please check your AS installation and make sure AS return client_id for introspection call (CE 3.1.0 or later)."),
     INACTIVE_ACCESS_TOKEN(403, "inactive_access_token", "Inactive access_token. Command is protected by access_token, please provide valid token or otherwise switch off protection in configuration with protect_commands_with_access_token=false"),
     INVALID_REDIRECT_URI(400, "invalid_redirect_uri", "Invalid redirect_uri (empty, blank or invalid)."),
+    URI_HAS_FRAGMENT_COMPONENT(400, "uri_has_fragment_component", "Fragment component is not allowed in redirect uri."),
     INVALID_SCOPE(400, "invalid_scope", "Invalid scope parameter (empty or blank)."),
     INVALID_ACR_VALUES(400, "invalid_acr_values", "Invalid acr_values parameter (empty or blank)."),
     INVALID_SIGNATURE_ALGORITHM(400, "invalid_algorithm", "Invalid algorithm provided. Valid algorithms are: " + Arrays.toString(SignatureAlgorithm.values())),

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Utils.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Utils.java
@@ -83,7 +83,7 @@ public class Utils {
         if (StringUtils.isNotBlank(url)) {
             try {
                 if (url.contains("#")) {
-                    throw new HttpException(ErrorResponseCode.URI_HAS_FRAGMENT_COMPONENT);
+                    throw new HttpException(ErrorResponseCode.REDIRECT_URI_HAS_FRAGMENT_COMPONENT);
                 }
                 new URL(url);
                 return true;

--- a/oxd-server/src/main/java/org/gluu/oxd/server/Utils.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/Utils.java
@@ -7,6 +7,7 @@ import com.google.common.base.Joiner;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.gluu.oxauth.model.util.Util;
+import org.gluu.oxd.common.ErrorResponseCode;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -81,6 +82,9 @@ public class Utils {
     public static boolean isValidUrl(String url) {
         if (StringUtils.isNotBlank(url)) {
             try {
+                if (url.contains("#")) {
+                    throw new HttpException(ErrorResponseCode.URI_HAS_FRAGMENT_COMPONENT);
+                }
                 new URL(url);
                 return true;
             } catch (MalformedURLException e) {

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/RegisterSiteOperation.java
@@ -13,7 +13,6 @@ import org.gluu.oxauth.client.RegisterRequest;
 import org.gluu.oxauth.client.RegisterResponse;
 import org.gluu.oxauth.model.common.AuthenticationMethod;
 import org.gluu.oxauth.model.common.GrantType;
-import org.gluu.oxauth.model.common.ResponseType;
 import org.gluu.oxauth.model.common.SubjectType;
 import org.gluu.oxauth.model.crypto.encryption.BlockEncryptionAlgorithm;
 import org.gluu.oxauth.model.crypto.encryption.KeyEncryptionAlgorithm;


### PR DESCRIPTION
#526 - Minor: Show clear error message when get `redirect_uri` with fragment component during registration instead of generic `invalid_redirect_uri`

https://github.com/GluuFederation/oxd/issues/526