### PR TITLE
#518 - For `private_key_jwt`, `tls_client_auth` , `self_signed_tls_client_auth` allow certificate-based client authentication.

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/CoreUtils.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/CoreUtils.java
@@ -185,8 +185,8 @@ public class CoreUtils {
     }
 
     /**
-     * @param trustStoreFile trust store file, e.g. D:/Development/gluu_conf/etc/certs/DA855F9895A1CA3B9E7D4BF5-java.jks
-     * @param trustStorePassword       key store password
+     * @param trustStoreFile     trust store file, e.g. D:/Development/gluu_conf/etc/certs/DA855F9895A1CA3B9E7D4BF5-java.jks
+     * @param trustStorePassword trust store password
      * @return http client
      * @throws Exception
      */

--- a/oxd-common/src/main/java/org/gluu/oxd/common/CoreUtils.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/CoreUtils.java
@@ -185,17 +185,30 @@ public class CoreUtils {
     }
 
     /**
-     * @param pathToKeyStore path to key store, e.g. D:/Development/gluu_conf/etc/certs/DA855F9895A1CA3B9E7D4BF5-java.jks
-     * @param password       key store password
+     * @param trustStoreFile trust store file, e.g. D:/Development/gluu_conf/etc/certs/DA855F9895A1CA3B9E7D4BF5-java.jks
+     * @param trustStorePassword       key store password
      * @return http client
      * @throws Exception
      */
 
 
-    public static HttpClient createHttpClientWithKeyStore(File pathToKeyStore, String password, String[] tlsVersions, String[] tlsSecureCiphers, Optional<ProxyConfiguration> proxyConfiguration) throws Exception {
+    public static HttpClient createHttpClientWithKeyStore(File trustStoreFile, String trustStorePassword, String[] tlsVersions, String[] tlsSecureCiphers, Optional<ProxyConfiguration> proxyConfiguration) throws Exception {
 
         SSLContext sslcontext = SSLContexts.custom()
-                .loadTrustMaterial(pathToKeyStore, password.toCharArray())
+                .loadTrustMaterial(trustStoreFile, trustStorePassword.toCharArray())
+                .build();
+
+        SSLConnectionSocketFactory sslConSocFactory = new SSLConnectionSocketFactory(
+                sslcontext, tlsVersions, tlsSecureCiphers, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+
+        return createClient(sslConSocFactory, proxyConfiguration);
+    }
+
+    public static HttpClient createHttpClientForMutualAuthentication(File trustStoreFile, String trustStorePassword, File mtlsClientKeyStoreFile, String mtlsClientKeyStorePassword, String[] tlsVersions, String[] tlsSecureCiphers, Optional<ProxyConfiguration> proxyConfiguration) throws Exception {
+
+        SSLContext sslcontext = SSLContexts.custom()
+                .loadKeyMaterial(mtlsClientKeyStoreFile, mtlsClientKeyStorePassword.toCharArray(), mtlsClientKeyStorePassword.toCharArray())
+                .loadTrustMaterial(trustStoreFile, trustStorePassword.toCharArray())
                 .build();
 
         SSLConnectionSocketFactory sslConSocFactory = new SSLConnectionSocketFactory(

--- a/oxd-server/src/main/java/org/gluu/oxd/server/OxdServerConfiguration.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/OxdServerConfiguration.java
@@ -93,6 +93,12 @@ public class OxdServerConfiguration extends Configuration {
     private List<String> tlsVersion;
     @JsonProperty(value = "tls_secure_cipher")
     private List<String> tlsSecureCipher;
+    @JsonProperty(value = "mtls_enabled")
+    private Boolean mtlsEnabled = false;
+    @JsonProperty(value = "mtls_client_key_store_path")
+    private String mtlsClientKeyStorePath;
+    @JsonProperty(value = "mtls_client_key_store_password")
+    private String mtlsClientKeyStorePassword;
 
     public Boolean getEnableTracing() {
         return enableTracing;
@@ -422,6 +428,30 @@ public class OxdServerConfiguration extends Configuration {
         this.tlsSecureCipher = tlsSecureCipher;
     }
 
+    public Boolean getMtlsEnabled() {
+        return mtlsEnabled;
+    }
+
+    public void setMtlsEnabled(Boolean mtlsEnabled) {
+        this.mtlsEnabled = mtlsEnabled;
+    }
+
+    public String getMtlsClientKeyStorePath() {
+        return mtlsClientKeyStorePath;
+    }
+
+    public void setMtlsClientKeyStorePath(String mtlsClientKeyStorePath) {
+        this.mtlsClientKeyStorePath = mtlsClientKeyStorePath;
+    }
+
+    public String getMtlsClientKeyStorePassword() {
+        return mtlsClientKeyStorePassword;
+    }
+
+    public void setMtlsClientKeyStorePassword(String mtlsClientKeyStorePassword) {
+        this.mtlsClientKeyStorePassword = mtlsClientKeyStorePassword;
+    }
+
     @Override
     public String toString() {
         return "OxdServerConfiguration{" +
@@ -461,6 +491,9 @@ public class OxdServerConfiguration extends Configuration {
                 ", requestObjectExpirationInMinutes=" + requestObjectExpirationInMinutes + '\'' +
                 ", jwksRegenerationIntervalInHours=" + jwksRegenerationIntervalInHours + '\'' +
                 ", tlsVersion=" + tlsVersion + '\'' +
+                ", mtlsEnabled=" + mtlsEnabled + '\'' +
+                ", mtlsClientKeyStorePath=" + mtlsClientKeyStorePath + '\'' +
+                ", mtlsClientKeyStorePassword=" + mtlsClientKeyStorePassword + '\'' +
                 '}';
     }
 }

--- a/oxd-server/src/main/java/org/gluu/oxd/server/service/HttpService.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/service/HttpService.java
@@ -6,7 +6,6 @@ package org.gluu.oxd.server.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
-import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.HttpClient;
 import org.gluu.oxd.common.CoreUtils;
 import org.gluu.oxd.common.Jackson2;
@@ -61,7 +60,7 @@ public class HttpService {
                 return CoreUtils.createClientFallback(proxyConfig);
             }
             //Perform mutual authentication over SSL if allowed
-            if(configuration.getMtlsEnabled()) {
+            if (configuration.getMtlsEnabled()) {
                 final String mtlsClientKeyStorePath = configuration.getMtlsClientKeyStorePath();
 
                 if (Strings.isNullOrEmpty(mtlsClientKeyStorePath)) {


### PR DESCRIPTION
#518  - For `private_key_jwt`, `tls_client_auth` , `self_signed_tls_client_auth` allow certificate-based client authentication.

https://github.com/GluuFederation/oxd/issues/518