### PR TITLE
#536 - If the ID Token contains multiple audiences, the Client shoud  verify that an azp Claim is present

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
@@ -39,6 +39,7 @@ public enum ErrorResponseCode {
     INVALID_ID_TOKEN_BAD_AUDIENCE(500, "invalid_id_token_bad_audience", "Invalid id_token. Audience value from token does not match audience from request."),
     INVALID_ID_TOKEN_NO_AUDIENCE(500, "invalid_id_token_no_audience", "Invalid id_token. Audience claim is missing from id_token."),
     INVALID_ID_TOKEN_BAD_AUTHORIZED_PARTY(500, "invalid_id_token_bad_authorized_party", "Invalid id_token. Authorized party value from token does not match client_id of client."),
+    INVALID_ID_TOKEN_NO_AUTHORIZED_PARTY(500, "invalid_id_token_no_authorized_party", "Invalid id_token. Authorized party (`azp`) is missing in ID Token."),
     INVALID_ID_TOKEN_EXPIRED(500, "invalid_id_token_expired", "Invalid id_token. id_token expired."),
     INVALID_ID_TOKEN_NO_ISSUER(500, "invalid_id_token_no_issuer", "Invalid id_token. Issuer claim is missing from id_token."),
     INVALID_ID_TOKEN_BAD_ISSUER(500, "invalid_id_token_bad_issuer", "Invalid id_token. Bad issuer."),

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/Validator.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/Validator.java
@@ -373,9 +373,14 @@ public class Validator {
                     LOG.error("ID Token has invalid audience (string list). Expected audience: " + clientId + ", audience from token is: " + audAsList);
                     throw new HttpException(ErrorResponseCode.INVALID_ID_TOKEN_BAD_AUDIENCE);
                 }
-                //If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
+
                 if (audAsList.size() > 1) {
                     String azpFromToken = idToken.getClaims().getClaimAsString(JwtClaimName.AUTHORIZED_PARTY);
+                    //If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
+                    if(Strings.isNullOrEmpty(azpFromToken)) {
+                        LOG.error("The ID Token has multiple audiences. Authorized party (`azp`) is missing in ID Token.");
+                        throw new HttpException(ErrorResponseCode.INVALID_ID_TOKEN_NO_AUTHORIZED_PARTY);
+                    }
                     //If an azp (authorized party) Claim is present, the Client SHOULD verify that its client_id is the Claim Value. If present, it MUST contain the OAuth 2.0 Client ID of this party.
                     if (!Strings.isNullOrEmpty(azpFromToken) && !azpFromToken.equalsIgnoreCase(clientId)) {
                         LOG.error("ID Token has invalid authorized party (string list). Expected authorized party: " + clientId + ", authorized party from token is: " + azpFromToken);


### PR DESCRIPTION
https://github.com/GluuFederation/oxd/issues/536