### PR TITLE
#537 - The algorithm used to sign the `id_token` should match with `id_token_signed_response_alg` set during client registration.

### DIFF
--- a/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
+++ b/oxd-common/src/main/java/org/gluu/oxd/common/ErrorResponseCode.java
@@ -44,6 +44,7 @@ public enum ErrorResponseCode {
     INVALID_ID_TOKEN_NO_ISSUER(500, "invalid_id_token_no_issuer", "Invalid id_token. Issuer claim is missing from id_token."),
     INVALID_ID_TOKEN_BAD_ISSUER(500, "invalid_id_token_bad_issuer", "Invalid id_token. Bad issuer."),
     INVALID_ID_TOKEN_BAD_SIGNATURE(500, "invalid_id_token_bad_signature", "Invalid id_token. Bad signature."),
+    INVALID_ID_TOKEN_INVALID_ALGORITHM(500, "invalid_id_token_invalid_algorithm", "Invalid id_token. The algorithm used to sign the ID Token does not matches with `id_token_signed_response_alg` algorithm set during client registration.."),
     INVALID_ID_TOKEN_UNKNOWN(500, "invalid_id_token_unknown", "Invalid id_token, validation fail due to exception, please check oxd-server.log for details."),
     INVALID_ACCESS_TOKEN_BAD_HASH(500, "invalid_access_token_bad_hash", "access_token is invalid. Hash of access_token does not match hash from id_token (at_hash)."),
     INVALID_STATE_BAD_HASH(500, "invalid_state_bad_hash", "State is invalid. Hash of state does not match hash from id_token (s_hash)."),

--- a/oxd-server/src/main/java/org/gluu/oxd/server/op/Validator.java
+++ b/oxd-server/src/main/java/org/gluu/oxd/server/op/Validator.java
@@ -319,10 +319,15 @@ public class Validator {
                 throw new HttpException(ErrorResponseCode.INVALID_ID_TOKEN_BAD_ISSUER);
             }
 
-            // 2. validate signature
+            //validate signature
             final String algorithm = idToken.getHeader().getClaimAsString(JwtHeaderName.ALGORITHM);
             final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.fromString(algorithm);
-
+            //validate algorithm
+            if (!Strings.isNullOrEmpty(rp.getIdTokenSignedResponseAlg()) &&
+                    SignatureAlgorithm.fromString(rp.getIdTokenSignedResponseAlg()) != signatureAlgorithm) {
+                LOG.error("The algorithm used to sign the ID Token does not matches with `id_token_signed_response_alg` algorithm set during client registration.");
+                throw new HttpException(ErrorResponseCode.INVALID_ID_TOKEN_INVALID_ALGORITHM);
+            }
             if (signatureAlgorithm != SignatureAlgorithm.NONE) {
                 boolean signature = jwsSigner.validate(idToken);
                 if (!signature) {


### PR DESCRIPTION
#537 - The algorithm used to sign the `id_token` should match with `id_token_signed_response_alg` set during client registration.
https://github.com/GluuFederation/oxd/issues/537