### PR TITLE
#557 - Automation of swagger client generation in oxd

### DIFF
--- a/oxd-client/pom.xml
+++ b/oxd-client/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <jersey.version>2.6</jersey.version> <!-- stick to 2.6 because 2.6 depends on Jackson 1.x, we don't want conflicts with Jackson 2.x-->
+        <skip.swagger.client.generation>true</skip.swagger.client.generation>
     </properties>
 
     <build>

--- a/oxd-common/pom.xml
+++ b/oxd-common/pom.xml
@@ -15,6 +15,10 @@
         <version>5.0.0-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <skip.swagger.client.generation>true</skip.swagger.client.generation>
+    </properties>
+
     <build>
         <finalName>oxd-common</finalName>
 

--- a/oxd-gen-client/pom.xml
+++ b/oxd-gen-client/pom.xml
@@ -288,5 +288,6 @@
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <skip.swagger.client.generation>true</skip.swagger.client.generation>
     </properties>
 </project>

--- a/oxd-server/pom.xml
+++ b/oxd-server/pom.xml
@@ -16,6 +16,7 @@
         <jersey-test-framework-provider>2.29.1</jersey-test-framework-provider>
         <generate.windows.exe>false</generate.windows.exe>
         <commons-daemon.bin.version>1.2.1</commons-daemon.bin.version>
+        <skip.swagger.client.generation>true</skip.swagger.client.generation>
     </properties>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -261,91 +261,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <profiles>
-        <profile>
-            <id>run-test-with-mocked-op-clients</id>
-            <activation>
-                <property>
-                    <name>benchmark</name>
-                </property>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <version>2.12.4</version>
-                            <configuration>
-                                <skipTests>false</skipTests>
-                                <failIfNoTests>false</failIfNoTests>
-                                <trimStackTrace>false</trimStackTrace>
-                                <suiteXmlFiles>
-                                    <suiteXmlFile>target/test-classes/testng-load.xml</suiteXmlFile>
-                                </suiteXmlFiles>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>generate-swagger-client</id>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.swagger.codegen.v3</groupId>
-                        <artifactId>swagger-codegen-maven-plugin</artifactId>
-                        <version>3.0.18</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>generate</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skip.swagger.client.generation}</skip>
-                                    <inputSpec>${project.basedir}/oxd-server/src/main/resources/swagger.yaml</inputSpec>
-                                    <output>${project.basedir}/target/generated-sources/swagger</output>
-                                    <language>java</language>
-                                    <generateApiTests>false</generateApiTests>
-                                    <generateModelDocumentation>false</generateModelDocumentation>
-                                    <generateApiDocumentation>false</generateApiDocumentation>
-                                    <configOptions>
-                                        <sourceFolder>gen</sourceFolder>
-                                        <hideGenerationTimestamp>true</hideGenerationTimestamp>
-                                    </configOptions>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.7</version>
-                        <executions>
-                            <execution>
-                                <id>delete-swagger-generated-client-from-builtDir</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skip.swagger.client.generation}</skip>
-                                    <target>
-                                        <copy todir="${project.basedir}/oxd-gen-client/src/main/java">
-                                            <fileset dir="${project.basedir}/target/generated-sources/swagger/gen"/>
-                                        </copy>
-                                        <delete dir="${project.basedir}/target"/>
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
     <build>
         <pluginManagement>
             <plugins>
@@ -442,5 +357,91 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>run-test-with-mocked-op-clients</id>
+            <activation>
+                <property>
+                    <name>benchmark</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <version>2.12.4</version>
+                            <configuration>
+                                <skipTests>false</skipTests>
+                                <failIfNoTests>false</failIfNoTests>
+                                <trimStackTrace>false</trimStackTrace>
+                                <suiteXmlFiles>
+                                    <suiteXmlFile>target/test-classes/testng-load.xml</suiteXmlFile>
+                                </suiteXmlFiles>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>generate-swagger-client</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.swagger.codegen.v3</groupId>
+                        <artifactId>swagger-codegen-maven-plugin</artifactId>
+                        <version>3.0.18</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skip.swagger.client.generation}</skip>
+                                    <inputSpec>${project.basedir}/oxd-server/src/main/resources/swagger.yaml</inputSpec>
+                                    <output>${project.basedir}/target/generated-sources/swagger</output>
+                                    <language>java</language>
+                                    <generateApiTests>false</generateApiTests>
+                                    <generateModelDocumentation>false</generateModelDocumentation>
+                                    <generateApiDocumentation>false</generateApiDocumentation>
+                                    <configOptions>
+                                        <sourceFolder>gen</sourceFolder>
+                                        <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                                    </configOptions>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.7</version>
+                        <executions>
+                            <execution>
+                                <id>delete-swagger-generated-client-from-builtDir</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skip.swagger.client.generation}</skip>
+                                    <target>
+                                        <copy todir="${project.basedir}/oxd-gen-client/src/main/java">
+                                            <fileset dir="${project.basedir}/target/generated-sources/swagger/gen"/>
+                                        </copy>
+                                        <delete dir="${project.basedir}/target"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <guava.version>[24.1.1,)</guava.version>
         <oxlicense.version>3.2.0-SNAPSHOT</oxlicense.version>
         <selenium.version>2.53.1</selenium.version>
+        <skip.swagger.client.generation>false</skip.swagger.client.generation>
     </properties>
 
     <prerequisites>
@@ -260,6 +261,91 @@
         </dependencies>
     </dependencyManagement>
 
+    <profiles>
+        <profile>
+            <id>run-test-with-mocked-op-clients</id>
+            <activation>
+                <property>
+                    <name>benchmark</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <version>2.12.4</version>
+                            <configuration>
+                                <skipTests>false</skipTests>
+                                <failIfNoTests>false</failIfNoTests>
+                                <trimStackTrace>false</trimStackTrace>
+                                <suiteXmlFiles>
+                                    <suiteXmlFile>target/test-classes/testng-load.xml</suiteXmlFile>
+                                </suiteXmlFiles>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>generate-swagger-client</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.swagger.codegen.v3</groupId>
+                        <artifactId>swagger-codegen-maven-plugin</artifactId>
+                        <version>3.0.18</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skip.swagger.client.generation}</skip>
+                                    <inputSpec>${project.basedir}/oxd-server/src/main/resources/swagger.yaml</inputSpec>
+                                    <output>${project.basedir}/target/generated-sources/swagger</output>
+                                    <language>java</language>
+                                    <generateApiTests>false</generateApiTests>
+                                    <generateModelDocumentation>false</generateModelDocumentation>
+                                    <generateApiDocumentation>false</generateApiDocumentation>
+                                    <configOptions>
+                                        <sourceFolder>gen</sourceFolder>
+                                        <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                                    </configOptions>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.7</version>
+                        <executions>
+                            <execution>
+                                <id>delete-swagger-generated-client-from-builtDir</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skip.swagger.client.generation}</skip>
+                                    <target>
+                                        <copy todir="${project.basedir}/oxd-gen-client/src/main/java">
+                                            <fileset dir="${project.basedir}/target/generated-sources/swagger/gen"/>
+                                        </copy>
+                                        <delete dir="${project.basedir}/target"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <build>
         <pluginManagement>
             <plugins>
@@ -356,35 +442,5 @@
             </plugins>
         </pluginManagement>
     </build>
-
-    <profiles>
-        <profile>
-            <id>run-test-with-mocked-op-clients</id>
-            <activation>
-                <property>
-                    <name>benchmark</name>
-                </property>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <version>2.12.4</version>
-                            <configuration>
-                                <skipTests>false</skipTests>
-                                <failIfNoTests>false</failIfNoTests>
-                                <trimStackTrace>false</trimStackTrace>
-                                <suiteXmlFiles>
-                                    <suiteXmlFile>target/test-classes/testng-load.xml</suiteXmlFile>
-                                </suiteXmlFiles>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-    </profiles>
 
 </project>


### PR DESCRIPTION
#557 - Automation of swagger client generation in oxd
https://github.com/GluuFederation/oxd/issues/557

Changes done 
 1. Generate swagger client using maven `swagger-codegen-maven-plugin` at starting in a temporary folder (`${oxd_home}/target/generated-sources`). 
2. Copy the generated sources from temporary folder to `oxd-gen-client` and delete the temporary folder.