### PR TITLE
fix: use ss instead of netstat in oxd-server startup script

### DIFF
--- a/debian/oxd-server
+++ b/debian/oxd-server
@@ -378,28 +378,28 @@ then
   echo "RUN_CMD      =  ${RUN_CMD[*]}"
 fi
 dip_in_logs() {
-	if [ ! -f $OXD_INIT_LOG ]; then
-		sleep 10
-	fi
-	echo "Checking logs for possible errors:"
-	INIT_START_STATUS=`tail -n 1 $OXD_INIT_LOG`
-	while true;
-	do
-		if [ "x$INIT_START_STATUS" != "x" ]; then
-			if [ "x$PREV_START_STATUS" = "x" ]; then
-				PREV_START_STATUS=$INIT_START_STATUS
-				sleep 10
-				INIT_START_STATUS=`tail -n 1 $OXD_INIT_LOG`
-			fi
-		fi
-		if [ "$INIT_START_STATUS" != "$PREV_START_STATUS" ]; then
-			PREV_START_STATUS=$INIT_START_STATUS	
-			sleep 10
-			INIT_START_STATUS=`tail -n 1 $OXD_INIT_LOG`
-		else
-			break;
-		fi
-	done	
+    if [ ! -f $OXD_INIT_LOG ]; then
+        sleep 10
+    fi
+    echo "Checking logs for possible errors:"
+    INIT_START_STATUS=`tail -n 1 $OXD_INIT_LOG`
+    while true;
+    do
+        if [ "x$INIT_START_STATUS" != "x" ]; then
+            if [ "x$PREV_START_STATUS" = "x" ]; then
+                PREV_START_STATUS=$INIT_START_STATUS
+                sleep 10
+                INIT_START_STATUS=`tail -n 1 $OXD_INIT_LOG`
+            fi
+        fi
+        if [ "$INIT_START_STATUS" != "$PREV_START_STATUS" ]; then
+            PREV_START_STATUS=$INIT_START_STATUS    
+            sleep 10
+            INIT_START_STATUS=`tail -n 1 $OXD_INIT_LOG`
+        else
+            break;
+        fi
+    done    
 }
 
 do_start () {
@@ -407,114 +407,114 @@ do_start () {
         if [ "x$PID_NUM" = "x" ]; then
                 echo "Starting $SERVICE_NAME:"
 
-    		if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
-    		then
-      			unset CH_USER
-      			if [ -n "$OXD_USER" ]
-      			then
-        			CH_USER="-c$OXD_USER"
-      			fi
+            if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
+            then
+                  unset CH_USER
+                  if [ -n "$OXD_USER" ]
+                  then
+                    CH_USER="-c$OXD_USER"
+                  fi
 
-			start-stop-daemon --start --quiet --chuid $OXD_USER --make-pidfile --pidfile $OXD_PID_FILE --background --exec $JAVA -- ${JAVA_OPTIONS[@]} >> $OXD_LOGS/start.log 2>&1
+            start-stop-daemon --start --quiet --chuid $OXD_USER --make-pidfile --pidfile $OXD_PID_FILE --background --exec $JAVA -- ${JAVA_OPTIONS[@]} >> $OXD_LOGS/start.log 2>&1
 
-			#dip_in_logs
-			sleep 4
-			for i in `seq 1 24`;
+            #dip_in_logs
+            sleep 4
+            for i in `seq 1 24`;
                         do
-                	        START_STATUS=`tail -n 4 $OXD_INIT_LOG|grep -i 'o.e.j.s.Server -  Started'` > /dev/null 2>&1
-                	        ERROR_STATUS=`tail -n 10 $OXD_INIT_LOG|egrep -i "Failed to start oxd server|Error"` > /dev/null 2>&1			        
-			        if [ "x$START_STATUS" != "x" ] || [ "x$ERROR_STATUS" != "x" ]; then
-		         	        break
-		         	fi
-				sleep 5
+                            START_STATUS=`tail -n 4 $OXD_INIT_LOG|grep -i 'o.e.j.s.Server -  Started'` > /dev/null 2>&1
+                            ERROR_STATUS=`tail -n 10 $OXD_INIT_LOG|egrep -i "Failed to start oxd server|Error"` > /dev/null 2>&1                    
+                    if [ "x$START_STATUS" != "x" ] || [ "x$ERROR_STATUS" != "x" ]; then
+                             break
+                     fi
+                sleep 5
                         done
-                	if [ "x$START_STATUS" = "x" ]; then
-                        	###If by chance log file doesn't provide necessary string, sleep another 10 seconds and check again PID of process
-                        	if [ "x$ERROR_STATUS" != "x" ]; then
-                                	### Since error occurred, we should remove the PID file at this point itself.
-					kill -9 `cat $OXD_PID_FILE` > /dev/null 2>&1
-					rm -f  $OXD_PID_FILE
-                                	echo "Some errors encountered..."
-                                	echo "See log below: "
-                                	echo ""
-                                	echo "$ERROR_STATUS"
-                                	echo ""
-                                	echo "For details please check $OXD_INIT_LOG ."
-                                	echo "Exiting..."
-                                	exit 1
-				else
-                                	### Since error occurred, we should remove the PID file at this point itself.
-					kill -9 `cat $OXD_PID_FILE` > /dev/null 2>&1
-					rm -f  $OXD_PID_FILE
-                                	echo "Some errors encountered..."
-                                	echo ""
-                                	echo "Exiting..."
-                                	exit 1				   
-                        	fi
-	
-                	fi
-        		chown "$OXD_USER" "$OXD_PID_FILE" > /dev/null 2>&1
-		else
-      			if [ -n "$OXD_USER" ] && [ `whoami` != "$OXD_USER" ]
-      			then
-        			unset SU_SHELL
-        			if [ "$OXD_SHELL" ]
-        			then
-          				SU_SHELL="-s $OXD_SHELL"
-        			fi
+                    if [ "x$START_STATUS" = "x" ]; then
+                            ###If by chance log file doesn't provide necessary string, sleep another 10 seconds and check again PID of process
+                            if [ "x$ERROR_STATUS" != "x" ]; then
+                                    ### Since error occurred, we should remove the PID file at this point itself.
+                    kill -9 `cat $OXD_PID_FILE` > /dev/null 2>&1
+                    rm -f  $OXD_PID_FILE
+                                    echo "Some errors encountered..."
+                                    echo "See log below: "
+                                    echo ""
+                                    echo "$ERROR_STATUS"
+                                    echo ""
+                                    echo "For details please check $OXD_INIT_LOG ."
+                                    echo "Exiting..."
+                                    exit 1
+                else
+                                    ### Since error occurred, we should remove the PID file at this point itself.
+                    kill -9 `cat $OXD_PID_FILE` > /dev/null 2>&1
+                    rm -f  $OXD_PID_FILE
+                                    echo "Some errors encountered..."
+                                    echo ""
+                                    echo "Exiting..."
+                                    exit 1                   
+                            fi
+    
+                    fi
+                chown "$OXD_USER" "$OXD_PID_FILE" > /dev/null 2>&1
+        else
+                  if [ -n "$OXD_USER" ] && [ `whoami` != "$OXD_USER" ]
+                  then
+                    unset SU_SHELL
+                    if [ "$OXD_SHELL" ]
+                    then
+                          SU_SHELL="-s $OXD_SHELL"
+                    fi
 
-        			touch "$OXD_PID_FILE"
-        			chown "$OXD_USER" "$OXD_PID_FILE"
-        			# FIXME: Broken solution: wordsplitting, pathname expansion, arbitrary command execution, etc.
-        			su - "$OXD_USER" $SU_SHELL -c "
-				exec $JAVA ${JAVA_OPTIONS[@]} >> "$OXD_LOGS/start.log" 2>&1 &
-          			disown \$!
-          			echo \$! > '$OXD_PID_FILE'"
-				#dip_in_logs
-			        sleep 4
-			        for i in `seq 1 24`;
+                    touch "$OXD_PID_FILE"
+                    chown "$OXD_USER" "$OXD_PID_FILE"
+                    # FIXME: Broken solution: wordsplitting, pathname expansion, arbitrary command execution, etc.
+                    su - "$OXD_USER" $SU_SHELL -c "
+                exec $JAVA ${JAVA_OPTIONS[@]} >> "$OXD_LOGS/start.log" 2>&1 &
+                      disown \$!
+                      echo \$! > '$OXD_PID_FILE'"
+                #dip_in_logs
+                    sleep 4
+                    for i in `seq 1 24`;
                                 do
-                		        START_STATUS=`tail -n 4 $OXD_INIT_LOG|grep -i 'o.e.j.s.Server -  Started'` > /dev/null 2>&1
-                		        ERROR_STATUS=`tail -n 10 $OXD_INIT_LOG|egrep -i "Failed to start oxd server|Error"` > /dev/null 2>&1                	                		        
-			                if [ "x$START_STATUS" != "x" ] || [ "x$ERROR_STATUS" != "x" ]; then
-		         	                break
-		                 	fi
-				        sleep 5
-                                done					
-                		if [ "x$START_STATUS" = "x" ]; then
-	                        	###If by chance log file doesn't provide necessary string, sleep another 10 seconds and check again PID of process
-	                        	if [ "x$ERROR_STATUS" != "x" ]; then
-	                                	### Since error occurred, we should remove the PID file at this point itself.
-						kill -9 `cat $OXD_PID_FILE` > /dev/null 2>&1
-						rm -f  $OXD_PID_FILE
-	                                	echo "Some errors encountered..."
-	                                	echo "See log below: "
-	                                	echo ""
-	                                	echo "$ERROR_STATUS"
-	                                	echo ""
-	                                	echo "For details please check $OXD_INIT_LOG ."
-	                                	echo "Exiting..."
-	                                	exit 1
-					else
-	                                	### Since error occurred, we should remove the PID file at this point itself.
-						kill -9 `cat $OXD_PID_FILE` > /dev/null 2>&1
-						rm -f  $OXD_PID_FILE
-	                                	echo "Some errors encountered..."
-	                                	echo ""
-	                                	echo "Exiting..."
-	                                	exit 1				   
-	                        	fi	
-	                	fi
-      			else
-        			$JAVA ${JAVA_OPTIONS[@]} > /dev/null &
-        			disown $!
-        			echo $! > "$OXD_PID_FILE"
-      			fi
-               	fi 	
-        	echo "PID: [`get_pid`]"
-        	echo "OK `date`"
-       	else
-                if netstat -tulpn | grep "$PID_NUM/java"; then
+                                START_STATUS=`tail -n 4 $OXD_INIT_LOG|grep -i 'o.e.j.s.Server -  Started'` > /dev/null 2>&1
+                                ERROR_STATUS=`tail -n 10 $OXD_INIT_LOG|egrep -i "Failed to start oxd server|Error"` > /dev/null 2>&1                                                    
+                            if [ "x$START_STATUS" != "x" ] || [ "x$ERROR_STATUS" != "x" ]; then
+                                     break
+                             fi
+                        sleep 5
+                                done                    
+                        if [ "x$START_STATUS" = "x" ]; then
+                                ###If by chance log file doesn't provide necessary string, sleep another 10 seconds and check again PID of process
+                                if [ "x$ERROR_STATUS" != "x" ]; then
+                                        ### Since error occurred, we should remove the PID file at this point itself.
+                        kill -9 `cat $OXD_PID_FILE` > /dev/null 2>&1
+                        rm -f  $OXD_PID_FILE
+                                        echo "Some errors encountered..."
+                                        echo "See log below: "
+                                        echo ""
+                                        echo "$ERROR_STATUS"
+                                        echo ""
+                                        echo "For details please check $OXD_INIT_LOG ."
+                                        echo "Exiting..."
+                                        exit 1
+                    else
+                                        ### Since error occurred, we should remove the PID file at this point itself.
+                        kill -9 `cat $OXD_PID_FILE` > /dev/null 2>&1
+                        rm -f  $OXD_PID_FILE
+                                        echo "Some errors encountered..."
+                                        echo ""
+                                        echo "Exiting..."
+                                        exit 1                   
+                                fi    
+                        fi
+                  else
+                    $JAVA ${JAVA_OPTIONS[@]} > /dev/null &
+                    disown $!
+                    echo $! > "$OXD_PID_FILE"
+                  fi
+                   fi     
+            echo "PID: [`get_pid`]"
+            echo "OK `date`"
+           else
+                if ss -plnt | grep "pid=$PID_NUM"; then
                         echo "$SERVICE_NAME is already running ..."
                         echo "PID: [$PID_NUM]"
                         exit 1
@@ -524,65 +524,65 @@ do_start () {
                         do_start
                         exit 0
                 fi
-	fi
+    fi
 }
 
 do_stop () {
-	PID_NUM=`get_pid`
+    PID_NUM=`get_pid`
         if [ "x$PID_NUM" != "x" ]; then 
-    		echo -n "Stopping $SERVICE_NAME: "
-    		if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1; then
-      			start-stop-daemon -K -p"$OXD_PID_FILE" -d"$OXD_HOME" -a "$JAVA" -s HUP
+            echo -n "Stopping $SERVICE_NAME: "
+            if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1; then
+                  start-stop-daemon -K -p"$OXD_PID_FILE" -d"$OXD_HOME" -a "$JAVA" -s HUP
 
-      			TIMEOUT=30
-      			while running "$OXD_PID_FILE"; do
-        			if (( TIMEOUT-- == 0 )); then
-          				start-stop-daemon -K -p"$OXD_PID_FILE" -d"$OXD_HOME" -a "$JAVA" -s KILL
-        			fi
+                  TIMEOUT=30
+                  while running "$OXD_PID_FILE"; do
+                    if (( TIMEOUT-- == 0 )); then
+                          start-stop-daemon -K -p"$OXD_PID_FILE" -d"$OXD_HOME" -a "$JAVA" -s KILL
+                    fi
 
-        			sleep 1
-      			done
-    		else
-      			if [ ! -f "$OXD_PID_FILE" ] ; then
-        			echo "ERROR: no pid found at $OXD_PID_FILE"
-        			exit 1
-      			fi
+                    sleep 1
+                  done
+            else
+                  if [ ! -f "$OXD_PID_FILE" ] ; then
+                    echo "ERROR: no pid found at $OXD_PID_FILE"
+                    exit 1
+                  fi
 
-      			PID=$(cat "$OXD_PID_FILE" 2>/dev/null)
-      			if [ -z "$PID" ] ; then
-        			echo "ERROR: no pid id found in $OXD_PID_FILE"
-        			exit 1
-      			fi
-      			kill "$PID" 2>/dev/null
+                  PID=$(cat "$OXD_PID_FILE" 2>/dev/null)
+                  if [ -z "$PID" ] ; then
+                    echo "ERROR: no pid id found in $OXD_PID_FILE"
+                    exit 1
+                  fi
+                  kill "$PID" 2>/dev/null
 
-      			TIMEOUT=30
-      			while running $OXD_PID_FILE; do
-        			if (( TIMEOUT-- == 0 )); then
-          				kill -KILL "$PID" 2>/dev/null
-        			fi
+                  TIMEOUT=30
+                  while running $OXD_PID_FILE; do
+                    if (( TIMEOUT-- == 0 )); then
+                          kill -KILL "$PID" 2>/dev/null
+                    fi
 
-        			sleep 1
-      			done
-    		fi
+                    sleep 1
+                  done
+            fi
 
-    		rm -f "$OXD_PID_FILE"
-    		rm -f "$OXD_STATE"
-    		echo OK
-	else
+            rm -f "$OXD_PID_FILE"
+            rm -f "$OXD_STATE"
+            echo OK
+    else
                 echo "$SERVICE_NAME is not running ..."     
-		exit 1
-	fi
+        exit 1
+    fi
 }
 ##################################################
 # Do the action
 ##################################################
 case "$ACTION" in
   start)
-	do_start
+    do_start
     ;;
 
   stop)
-	do_stop
+    do_stop
     ;;
 
   restart)


### PR DESCRIPTION
`netstat` is not default in recent distros, `ss` is modern replacement and default. In this PR I also cleaned mixed whitespaces.